### PR TITLE
Add bootstrap script for uploading files for `prio-processor staging`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,8 +12,8 @@ examples/*/Pipfile.lock
 .vscode
 .tox
 
-build/
 data/
-dist/
-working/
-venv/
+**/build/
+**/dist/
+**/working/
+**/venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV PATH="$PATH:~/.local/bin"
 RUN python3 -m ensurepip && pip3 install tox setuptools wheel
 
 RUN curl https://sdk.cloud.google.com | bash
-ENV PATH $PATH:~/google-cloud-sdk/bin
+ENV PATH="$PATH:~/google-cloud-sdk/bin"
 RUN gcloud config set disable_usage_reporting true
 
 # install the app
@@ -56,17 +56,18 @@ FROM centos:7 as production
 ENV LANG en_US.utf8
 
 RUN yum install -y epel-release \
-    && yum install -y nss nspr msgpack jq python36 parallel java-1.8.0-openjdk \
+    && yum install -y which nss nspr msgpack jq python36 parallel java-1.8.0-openjdk \
     && yum clean all \
     && rm -rf /var/cache/yum
 
 RUN groupadd --gid 10001 app && \
     useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home \
         --home-dir /app app
-RUN chown -R 10001:10001 /app
 
 WORKDIR /app
 COPY --from=development /app .
+RUN chown -R 10001:10001 /app
+
 ENV PATH="$PATH:~/.local/bin"
 RUN python3 -m ensurepip \
         && pip3 install \
@@ -75,6 +76,10 @@ RUN python3 -m ensurepip \
                 ./processor
 
 USER app
+RUN curl https://sdk.cloud.google.com | bash
+ENV PATH="$PATH:~/google-cloud-sdk/bin"
+RUN gcloud config set disable_usage_reporting true
+
 CMD pytest && scripts/test-cli-integration
 
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -27,6 +27,59 @@ and `moz-fx-priotest-project-b` Google Cloud Platform. To request service
 account access, file a bug under [Data Platform and Tools ::
 Operations](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools).
 
+### Running the `staging` job
+
+A Spark job populates the processors with data from Mozilla's ingestion system.
+You will need a project that is configured in the Firefox data operations
+sandbox, configured with a service account for running Cloud DataProc.
+
+Initialize a dataproc cluster with the appropriate dependencies installed:
+
+```bash
+gcloud dataproc clusters create test-cluster \
+    --zone <ZONE> \
+    --image-version 1.4 \
+    --metadata 'PIP_PACKAGES=click' \
+    --service-account <SERVICE_ACCOUNT_ADDRESS> \
+    --initialization-actions \
+        gs://dataproc-initialization-actions/python/pip-install.sh
+```
+
+Run the bootstrap command from the container to populate a prefix in a
+storage bucket with the python module.
+
+```bash
+docker run \
+    -e GOOGLE_APPLICATION_CREDENTIALS=/app/.credentials \
+    -v <CREDENTIAL_FILE>:/app/.credentials \
+    -it prio:latest bash -c \
+        "cd processor; prio-processor bootstrap --output gs://<BUCKET>/bootstrap/"
+```
+
+Run the job.
+
+```bash
+gcloud dataproc jobs submit pyspark \
+    gs://<BUCKET>/bootstrap/runner.py \
+    --cluster test-cluster  \
+    --py-files gs://<BUCKET>/bootstrap/prio_processor.egg \
+        -- \
+        --date <YYYY-MM-DD> \
+        --input gs://moz-fx-data-stage-data/telemetry-decoded_gcs-sink-doctype_prio/output \
+        --output gs://<BUCKET>/prio_staging/
+```
+
+Clean up the resources, and copy the files into the private buckets to initiate
+the batched processing scheme.
+
+```bash
+gsutil rm -r gs://<BUCKET>/bootstrap/
+gcloud dataproc clusters delete test-cluster
+```
+
+See [PR#62](https://github.com/mozilla/prio-processor/pull/62#issue-298714211)
+for more details.
+
 ## Overview
 
 The bin folder contains scripts for data processing in Google Cloud Platform

--- a/processor/prio_processor/__main__.py
+++ b/processor/prio_processor/__main__.py
@@ -1,0 +1,15 @@
+import logging
+import click
+from . import bootstrap, staging
+
+logging.basicConfig(level=logging.INFO)
+
+
+@click.group()
+def entry_point():
+    pass
+
+
+entry_point.add_command(bootstrap.run, "bootstrap")
+entry_point.add_command(staging.run, "staging")
+entry_point()

--- a/processor/prio_processor/bootstrap.py
+++ b/processor/prio_processor/bootstrap.py
@@ -1,0 +1,43 @@
+import click
+import glob
+import logging
+
+from gcsfs import GCSFileSystem
+
+
+@click.command()
+@click.option(
+    "--output",
+    type=str,
+    required=True,
+    help="The output directory for temporary files required by dataproc",
+)
+@click.option(
+    "--token",
+    envvar="GOOGLE_APPLICATION_CREDENTIALS",
+    help="Path to google application credentials",
+    required=False,
+)
+def run(output, token):
+    """This script uploads the artifacts needed to run the `staging` job."""
+
+    output = output.rstrip("/")
+    egg_listing = glob.glob("dist/prio_processor-*.egg")
+    if not egg_listing:
+        raise RuntimeError("missing bdist_egg artifact")
+    if len(egg_listing) > 1:
+        raise RuntimeError("there are multiple eggs")
+
+    fs = GCSFileSystem(output, token=token)
+
+    egg = egg_listing[0]
+    logging.info(f"writing {egg} to {output}/{egg}")
+    fs.put(egg, f"{output}/{egg}")
+
+    logging.info(f"writing runner.py to {output}/runner.py")
+    with fs.open(f"{output}/runner.py", "w") as f:
+        f.write("from prio_processor import staging; staging.run()")
+
+
+if __name__ == "__main__":
+    run()

--- a/processor/prio_processor/bootstrap.py
+++ b/processor/prio_processor/bootstrap.py
@@ -29,10 +29,10 @@ def run(output, token):
     if len(egg_listing) > 1:
         raise RuntimeError("there are multiple eggs")
 
-    fs = GCSFileSystem(output, token=token)
+    fs = GCSFileSystem(token=token)
 
     egg = egg_listing[0]
-    outfile = "output/prio_processor.egg"
+    outfile = f"{output}/prio_processor.egg"
     logging.info(f"writing {egg} to {outfile}")
     fs.put(egg, outfile)
 

--- a/processor/prio_processor/bootstrap.py
+++ b/processor/prio_processor/bootstrap.py
@@ -14,6 +14,7 @@ from gcsfs import GCSFileSystem
 )
 @click.option(
     "--token",
+    type=str,
     envvar="GOOGLE_APPLICATION_CREDENTIALS",
     help="Path to google application credentials",
     required=False,
@@ -31,8 +32,9 @@ def run(output, token):
     fs = GCSFileSystem(output, token=token)
 
     egg = egg_listing[0]
-    logging.info(f"writing {egg} to {output}/{egg}")
-    fs.put(egg, f"{output}/{egg}")
+    outfile = "output/prio_processor.egg"
+    logging.info(f"writing {egg} to {outfile}")
+    fs.put(egg, outfile)
 
     logging.info(f"writing runner.py to {output}/runner.py")
     with fs.open(f"{output}/runner.py", "w") as f:

--- a/processor/setup.py
+++ b/processor/setup.py
@@ -8,6 +8,7 @@ setup(
     author="Anthony Miyaguchi",
     author_email="amiyaguchi@mozilla.com",
     url="https://github.com/mozilla/prio-processor",
-    install_requires=["click", "pyspark >= 2.4.0"],
+    entry_points={"console_scripts": ["prio-processor=prio_processor.__main__:entry_point"]},
+    install_requires=["click", "gcsfs", "pyspark >= 2.4.0"],
     packages=["prio_processor"],
 )

--- a/processor/tox.ini
+++ b/processor/tox.ini
@@ -6,7 +6,6 @@ deps =
     pytest
     pyyaml
     python-dotenv
-    gcsfs
 commands = pytest {posargs}
 
 [pytest]


### PR DESCRIPTION
I've added a new command to the `prio-processor` command line tool, which uploads a runner script and the generated egg to a dataproc cluster. 

Here's the testing script -- note that the gcloud dataproc commands do not reference local files at all.

```bash
gcloud dataproc clusters create test-cluster \
    --zone us-east1-b \
    --image-version 1.4 \
    --metadata 'PIP_PACKAGES=click' \
    --service-account dataproc-worker@amiyaguchi-dev.iam.gserviceaccount.com \
    --initialization-actions \
    gs://dataproc-initialization-actions/python/pip-install.sh

docker run \
	-e GOOGLE_APPLICATION_CREDENTIALS=/app/.credentials \
	-v ~/gcp-service-credentials/amiyaguchi-dev-dbf99a102977.json:/app/.credentials \
	-it prio:latest bash -c "cd processor; prio-processor bootstrap --output gs://amiyaguchi-dev/bootstrap/"

gcloud dataproc jobs submit pyspark \
    gs://amiyaguchi-dev/bootstrap/runner.py \
    --cluster test-cluster  \
    --py-files gs://amiyaguchi-dev/bootstrap/prio_processor.egg \
        -- \
        --date 2019-06-27 \
        --input gs://moz-fx-data-stage-data/telemetry-decoded_gcs-sink-doctype_prio/output \
        --output gs://amiyaguchi-dev/prio_staging/

docker run \
	-e GOOGLE_APPLICATION_CREDENTIALS=/app/.credentials \
	-v ~/gcp-service-credentials/amiyaguchi-dev-dbf99a102977.json:/app/.credentials \
	-it prio:latest bash -c "gcloud auth activate-service-account --key-file ~/.credentials; gsutil rm -r gs://amiyaguchi-dev/bootstrap/"

gcloud dataproc clusters delete test-cluster
```

[Flowchart](https://mermaidjs.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggTFJcblxuYWlyZmxvd1xuZGF0YXByb2Ncblxuc3ViZ3JhcGggcHJvY2Vzc29yXG5ib290c3RyYXBcbnNvdXJjZVxuZW5kXG5cbnN1YmdyYXBoIGdjc1xuZGVwc1xub3V0cHV0XG5lbmRcblxuYWlyZmxvdyAtLXN0YXJ0cy0tPiBkYXRhcHJvY1xuc291cmNlIC0tZmVlZHMtLT4gYm9vdHN0cmFwXG5haXJmbG93IC0tcnVucy0tPiBib290c3RyYXBcbmJvb3RzdHJhcCAtLXBvcHVsYXRlcy0tPiBkZXBzXG5haXJmbG93IC0tc3VibWl0cyBqb2ItLT4gZGF0YXByb2NcbmRlcHMgLS1hcmUgdXNlZCBieS0tPiBkYXRhcHJvY1xuZGF0YXByb2MgLS1nZW5lcmF0ZXMtLT4gb3V0cHV0XG5haXJmbG93IC0tc3RvcHMtLT5kYXRhcHJvYyIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19)
![image](https://user-images.githubusercontent.com/3304040/61420442-54ff2680-a8b7-11e9-9d90-cdfd952ba46f.png)

