### PR TITLE
Update authentication for kubernetes engine scopes

### DIFF
--- a/processor/bin/cleanup
+++ b/processor/bin/cleanup
@@ -8,8 +8,21 @@ set -x
 
 : "${BUCKET_INTERNAL_PRIVATE?}"
 : "${BUCKET_INTERNAL_SHARED?}"
-: "${GOOGLE_APPLICATION_CREDENTIALS?}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:=}"
 
-gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}"
+function authenticate() {
+    local cred=${GOOGLE_APPLICATION_CREDENTIALS}
+    local test_bucket=${BUCKET_INTERNAL_PRIVATE}
+
+    if [[ -n "${cred}" ]]; then
+        gcloud auth activate-service-account --key-file "${cred}"
+    else
+        # https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform
+        echo "No JSON credentials provided, using default scopes."
+    fi
+    gsutil ls "gs://${test_bucket}"
+}
+
+authenticate
 (gsutil -m rm "gs://${BUCKET_INTERNAL_PRIVATE}/**" || echo "nothing to delete")
 (gsutil -m rm "gs://${BUCKET_INTERNAL_SHARED}/**" || echo "nothing to delete")

--- a/processor/bin/process
+++ b/processor/bin/process
@@ -28,9 +28,9 @@ export DATA_CONFIG=${DATA_CONFIG?}
 : "${BUCKET_INTERNAL_PRIVATE?}"
 : "${BUCKET_INTERNAL_SHARED?}"
 : "${BUCKET_EXTERNAL_SHARED?}"
-: "${GOOGLE_APPLICATION_CREDENTIALS?}"
 
 # Assign to a default if variables are unset.
+: "${GOOGLE_APPLICATION_CREDENTIALS:=}"
 : "${RETRY_LIMIT:=5}"
 : "${RETRY_DELAY:=2}"
 : "${RETRY_BACKOFF_EXPONENT:=2}"
@@ -291,8 +291,16 @@ function publish() {
 }
 
 function authenticate() {
-    local cred="${GOOGLE_APPLICATION_CREDENTIALS?}"
-    gcloud auth activate-service-account --key-file "${cred}"
+    local cred=${GOOGLE_APPLICATION_CREDENTIALS}
+    local test_bucket=${BUCKET_INTERNAL_PRIVATE}
+
+    if [[ -n "${cred}" ]]; then
+        gcloud auth activate-service-account --key-file "${cred}"
+    else
+        # https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform
+        echo "No JSON credentials provided, using default scopes."
+    fi
+    gsutil ls "gs://${test_bucket}"
 }
 
 function main() {

--- a/processor/setup.py
+++ b/processor/setup.py
@@ -9,6 +9,6 @@ setup(
     author_email="amiyaguchi@mozilla.com",
     url="https://github.com/mozilla/prio-processor",
     entry_points={"console_scripts": ["prio-processor=prio_processor.__main__:entry_point"]},
-    install_requires=["click", "gcsfs", "pyspark >= 2.4.0"],
+    install_requires=["click", "gcsfs == 0.2.3", "pyspark >= 2.4.0"],
     packages=["prio_processor"],
 )

--- a/processor/setup.py
+++ b/processor/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="prio_processor",
-    version="1.1.0",
+    version="1.2.0",
     description="A processing engine for prio data",
     long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",


### PR DESCRIPTION
This will avoid failing if GOOGLE_APPLICATION_CREDENTIALS are not set, and instead assume the roles from the current scope if running inside of google kubernetes engine (GKE).