### PR TITLE
Remove printing of aggregates due to incorrect globbing

### DIFF
--- a/processor/bin/process
+++ b/processor/bin/process
@@ -301,8 +301,6 @@ function publish() {
     export -f process
     parallel process ::: "$(list_partitions ${input_internal})"
 
-    jq -c '.' ${output}/**/*.json
-
     send_output_internal ${output}
 }
 

--- a/processor/setup.py
+++ b/processor/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="prio_processor",
-    version="1.2.1",
+    version="1.2.2",
     description="A processing engine for prio data",
     long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",


### PR DESCRIPTION
The following error appears:
```
[2019-08-14 22:05:03,982] {logging_mixin.py:95} INFO - [2019-08-14 22:05:03,982] {pod_launcher.py:104} INFO - Running publish
[2019-08-14 22:05:03,990] {logging_mixin.py:95} INFO - [2019-08-14 22:05:03,990] {pod_launcher.py:104} INFO - + jq -c . 'processed/**/*.json'
[2019-08-14 22:05:03,998] {logging_mixin.py:95} INFO - [2019-08-14 22:05:03,998] {pod_launcher.py:104} INFO - jq: error: Could not open file processed/**/*.json: No such file or directory
[2019-08-14 22:05:09,083] {logging_mixin.py:95} INFO - [2019-08-14 22:05:09,083] {pod_launcher.py:121} INFO - Event: run-prio-project-a-15291eba had an event of type Failed
[2019-08-14 22:05:09,084] {logging_mixin.py:95} INFO - [2019-08-14 22:05:09,083] {pod_launcher.py:181} INFO - Event with job id run-prio-project-a-15291eba Failed
[2019-08-14 22:05:09,126] {logging_mixin.py:95} INFO - [2019-08-14 22:05:09,126] {pod_launcher.py:121} INFO - Event: run-prio-project-a-15291eba had an event of type Failed
[2019-08-14 22:05:09,127] {logging_mixin.py:95} INFO - [2019-08-14 22:05:09,127] {pod_launcher.py:181} INFO - Event with job id run-prio-project-a-15291eba Failed
[2019-08-14 22:05:09,143] {models.py:1788} ERROR - Pod Launching failed: Pod returned a failure: failed
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/airflow/models.py", line 1657, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/app/dags/operators/gcp_container_operator.py", line 55, in execute
    super(GKEPodOperator, self).execute(context)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/operators/gcp_container_operator.py", line 280, in execute
    super(GKEPodOperator, self).execute(context)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 145, in execute
    raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
AirflowException: Pod Launching failed: Pod returned a failure: failed
[2019-08-14 22:05:09,151] {models.py:1819} INFO - Marking task as FAILED.
```

This piece of code is just a diagnostic piece anyways -- it's not necessary to keep as part of the processing pipeline.