### PR TITLE
Update commands to succeed when inputs are not encoded correctly 

### DIFF
--- a/prio/cli/commands.py
+++ b/prio/cli/commands.py
@@ -4,7 +4,6 @@ import json
 import os
 from base64 import b64decode, b64encode
 from uuid import uuid4
-import logging
 
 from .. import libprio
 from .options import (
@@ -130,8 +129,7 @@ def verify1(
     outfile = os.path.join(output, name)
     os.makedirs(output, exist_ok=True)
 
-    total = 0
-    error = 0
+    total, error = 0, 0
     with open(outfile, "w") as f:
         for datum in data:
             total += 1
@@ -202,8 +200,7 @@ def verify2(
     outfile = os.path.join(output, name)
     os.makedirs(output, exist_ok=True)
 
-    total = 0
-    error = 0
+    total, error = 0, 0
     with open(outfile, "w") as f:
         for datum in data:
             total += 1
@@ -277,8 +274,7 @@ def aggregate(
     internal_index = {d["id"]: d["payload"] for d in data_internal}
     external_index = {d["id"]: d["payload"] for d in data_external}
 
-    total = 0
-    error = 0
+    total, error = 0, 0
     for datum in data:
         total += 1
         try:


### PR DESCRIPTION
Currently the command-line tools will fail if any of the inputs in the current batch do not match with the configuration. This counts the number of bad payloads and continues with the process instead.

```
+ parallel process ::: 'submission_date=2019-08-12/batch_id=content.blocking_blocked-0/part-00000-bc73a2e5-b3b5-4b50-a2a3-f20617e0e656.c000.json
submission_date=2019-08-12/batch_id=content.blocking_blocked_TESTONLY-1/part-00000-bc73a2e5-b3b5-4b50-a2a3-f20617e0e656.c000.json
submission_date=2019-08-12/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-bc73a2e5-b3b5-4b50-a2a3-f20617e0e656.c000.json
submission_date=2019-08-12/batch_id=content.blocking_blocked-1/part-00000-bc73a2e5-b3b5-4b50-a2a3-f20617e0e656.c000.json'
Academic tradition requires you to cite works you base your article on.
When using programs that use GNU Parallel to process data for publication
please cite:

  O. Tange (2011): GNU Parallel - The Command-Line Power Tool,
  ;login: The USENIX Magazine, February 2011:42-47.

This helps funding further development; AND IT WON'T COST YOU A CENT.
If you pay 10000 EUR you should feel free to use GNU Parallel without citing.

To silence the citation notice: run 'parallel --bibtex'.

content.blocking_blocked-0 has unknown dimension, skipping...
content.blocking_blocked-1 has unknown dimension, skipping...
Running verify1
6 errors out of 256 total
Running verify1
6 errors out of 256 total
+ send_output_external intermediate/internal/verify1 intermediate/external/verify1
+ : project-b-shared
+ local output_internal=intermediate/internal/verify1
+ local output_external=intermediate/external/verify1
+ local path=gs://project-b-shared/intermediate/external/verify1
+ gsutil -m rsync -r intermediate/internal/verify1/ gs://project-b-shared/intermediate/external/verify1/
```

