### PR TITLE
Ignore KeyErrors due to invalid data during joins

### DIFF
--- a/examples/batched-processing/scripts/bootstrap.sh
+++ b/examples/batched-processing/scripts/bootstrap.sh
@@ -13,6 +13,10 @@ mc mb $TARGET/server-b
 mc admin policy add $TARGET server-a policy/server-a.json
 mc admin policy add $TARGET server-b policy/server-b.json
 
-# mc admin user add TARGET ACCESSKEY SECRETKEY POLICYNAME
-mc admin user add $TARGET server-a password server-a
-mc admin user add $TARGET server-b password server-b
+# mc admin user add TARGET ACCESSKEY SECRETKEY
+mc admin user add $TARGET server-a password
+mc admin user add $TARGET server-b password
+
+# mc admin policy set TARGET POLICYNAME user=ACCESSKEY
+mc admin policy set $TARGET server-a user=server-a
+mc admin policy set $TARGET server-b user=server-b

--- a/prio/cli/commands.py
+++ b/prio/cli/commands.py
@@ -220,7 +220,7 @@ def verify2(
                 datum["payload"] = b64encode(packet_data).decode()
                 json.dump(datum, f)
                 f.write("\n")
-            except RuntimeError:
+            except (RuntimeError, KeyError):
                 error += 1
     click.echo(f"{error} errors out of {total} total")
 
@@ -287,7 +287,7 @@ def aggregate(
             libprio.PrioPacketVerify2_read(packet2_external, external, config)
             libprio.PrioVerifier_isValid(verifier, packet2_internal, packet2_external)
             libprio.PrioServer_aggregate(server, verifier)
-        except RuntimeError:
+        except (RuntimeError, KeyError):
             error += 1
     click.echo(f"{error} errors out of {total} total")
 

--- a/prio/cli/commands.py
+++ b/prio/cli/commands.py
@@ -4,7 +4,6 @@ import json
 import os
 from base64 import b64decode, b64encode
 from uuid import uuid4
-import logging
 
 from .. import libprio
 from .options import (
@@ -130,8 +129,7 @@ def verify1(
     outfile = os.path.join(output, name)
     os.makedirs(output, exist_ok=True)
 
-    total = 0
-    error = 0
+    total, error = 0, 0
     with open(outfile, "w") as f:
         for datum in data:
             total += 1
@@ -202,8 +200,7 @@ def verify2(
     outfile = os.path.join(output, name)
     os.makedirs(output, exist_ok=True)
 
-    total = 0
-    error = 0
+    total, error = 0, 0
     with open(outfile, "w") as f:
         for datum in data:
             total += 1
@@ -277,8 +274,7 @@ def aggregate(
     internal_index = {d["id"]: d["payload"] for d in data_internal}
     external_index = {d["id"]: d["payload"] for d in data_external}
 
-    total = 0
-    error = 0
+    total, error = 0, 0
     for datum in data:
         total += 1
         try:

--- a/processor/bin/generate
+++ b/processor/bin/generate
@@ -78,6 +78,10 @@ function generate_dataset() {
             --n-data "${n_data}" \
             --output-A "${out_a}" \
             --output-B "${out_b}"
+
+        # test for robustness by inserting an invalid entry into the shares
+        echo '{"id": "asdf", "payload": "asdf"}' >> "${out_a}/${filename}"
+        echo '{"id": "asdf", "payload": "asdf"}' >> "${out_b}/${filename}"
     done
 }
 

--- a/processor/setup.py
+++ b/processor/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="prio_processor",
-    version="1.2.2",
+    version="1.2.3",
     description="A processing engine for prio data",
     long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",


### PR DESCRIPTION
`verify2` and `aggregate` would fail during processing due to a KeyError when joining the original payloads against the outputs of `verify1` or `verify2`. This is based on the way that the commands join the two streams of data, which iterates over all the payloads that were received in the beginning. This simply treats missing data as an error that is logged.

I add a simple test where each of the test partitions is appended with garbage to test robustness. See the following logs for the new output: https://gist.github.com/acmiyaguchi/843dd98c59dd600c96d2dc8db9f00bb5