### PR TITLE
Add BigQuery reads on the Prio payload_decode_bytes table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN python3 setup.py bdist_wheel && pip3 install dist/prio-*.whl
 WORKDIR /app/processor
 RUN pip3 install . && python3 setup.py bdist_egg
 
+ENV SPARK_HOME=/usr/local/lib/python3.6/site-packages/pyspark
+ENV PYSPARK_PYTHON=python3
+
 WORKDIR /app
 CMD make test
 
@@ -74,6 +77,9 @@ RUN python3 -m ensurepip \
                 pytest \
                 ./dist/prio-*.whl \
                 ./processor
+
+ENV SPARK_HOME=/usr/local/lib/python3.6/site-packages/pyspark
+ENV PYSPARK_PYTHON=python3
 
 USER app
 RUN curl https://sdk.cloud.google.com | bash

--- a/processor/README.md
+++ b/processor/README.md
@@ -62,10 +62,12 @@ Run the job.
 gcloud dataproc jobs submit pyspark \
     gs://<BUCKET>/bootstrap/runner.py \
     --cluster test-cluster  \
+    --jars gs://spark-lib/bigquery/spark-bigquery-latest.jar \
     --py-files gs://<BUCKET>/bootstrap/prio_processor.egg \
         -- \
+        --source bigquery \
         --date <YYYY-MM-DD> \
-        --input gs://moz-fx-data-stage-data/telemetry-decoded_gcs-sink-doctype_prio/output \
+        --input moz-fx-data-shar-nonprod-efed.payload_bytes_decoded.telemetry_telemetry__prio_v4 \
         --output gs://<BUCKET>/prio_staging/
 ```
 

--- a/processor/prio_processor/bootstrap.py
+++ b/processor/prio_processor/bootstrap.py
@@ -1,8 +1,22 @@
-import click
 import glob
 import logging
+import os
+from shutil import copyfile
 
+import click
 from gcsfs import GCSFileSystem
+
+
+class LocalFileSystem:
+    """Shim for writing files locally."""
+
+    def put(self, src, dst):
+        dirname = os.path.dirname(dst)
+        os.makedirs(dirname, exist_ok=True)
+        copyfile(src, dst)
+
+    def open(self, *args, **kwargs):
+        return open(*args, **kwargs)
 
 
 @click.command()
@@ -13,13 +27,13 @@ from gcsfs import GCSFileSystem
     help="The output directory for temporary files required by dataproc",
 )
 @click.option(
-    "--token",
+    "--credentials",
     type=str,
     envvar="GOOGLE_APPLICATION_CREDENTIALS",
     help="Path to google application credentials",
     required=False,
 )
-def run(output, token):
+def run(output, credentials):
     """This script uploads the artifacts needed to run the `staging` job."""
 
     output = output.rstrip("/")
@@ -29,7 +43,10 @@ def run(output, token):
     if len(egg_listing) > 1:
         raise RuntimeError("there are multiple eggs")
 
-    fs = GCSFileSystem(token=token)
+    if output.startswith("gs://"):
+        fs = GCSFileSystem(token=credentials)
+    else:
+        fs = LocalFileSystem()
 
     egg = egg_listing[0]
     outfile = f"{output}/prio_processor.egg"

--- a/processor/prio_processor/staging.py
+++ b/processor/prio_processor/staging.py
@@ -1,17 +1,20 @@
-from abc import ABC, abstractmethod
-import click
+import gzip
 import json
 import math
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
 
-from pyspark.sql import SparkSession, Row, functions as F
-from pyspark.sql.functions import udf, explode, row_number, lit, col, length, unbase64
+import click
+from pyspark.sql import Row, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.functions import col, explode, length, lit, row_number, udf, unbase64
 from pyspark.sql.types import (
-    StructType,
-    StructField,
     ArrayType,
-    StringType,
-    MapType,
     ByteType,
+    MapType,
+    StringType,
+    StructField,
+    StructType,
 )
 from pyspark.sql.window import Window
 
@@ -72,6 +75,36 @@ class CloudStorageExtract(ExtractPrioPing):
         ).select("extracted.*")
 
 
+class BigQueryStorageExtract(ExtractPrioPing):
+    @staticmethod
+    def date_add(date_ds: str, days: int) -> str:
+        fmt = "%Y-%m-%d"
+        dt = datetime.strptime(date_ds, fmt)
+        return datetime.strftime(dt + timedelta(days), fmt)
+
+    @staticmethod
+    @udf(ExtractPrioPing.payload_schema)
+    def extract_payload_udf(ping):
+        data = json.loads(gzip.decompress(ping).decode("utf-8"))
+        return Row(id=data["id"], prioData=data["payload"]["prioData"])
+
+    def extract(self, table, date):
+        """Extract data from the payload_bytes_decoded BigQuery table."""
+        df = (
+            self.spark.read.format("bigquery")
+            .option("table", table)
+            .option(
+                "filter",
+                f"submission_timestamp >= '{date}'"
+                f" AND submission_timestamp < '{self.date_add(date, 1)}'",
+            )
+            .load()
+        )
+        return df.select(
+            self.extract_payload_udf(col("payload")).alias("extracted")
+        ).select("extracted.*")
+
+
 def estimate_num_partitions(df, column="prio", partition_size_mb=250):
     size_b = df.select(F.sum(length(column)).alias("size")).collect()[0].size
     return math.ceil(size_b * 1.0 / 10 ** 6 / partition_size_mb)
@@ -118,13 +151,41 @@ def load(data, output, date):
 
 
 @click.command()
-@click.option("--date", type=str, required=True)
-@click.option("--input", type=str, required=True)
-@click.option("--output", type=str, required=True)
-def run(date, input, output):
+@click.option(
+    "--date",
+    type=str,
+    required=True,
+    help="The submission date for filtering in YYYY-MM-DD format",
+)
+@click.option(
+    "--input",
+    type=str,
+    required=True,
+    help="The fully-qualified GCS path or BigQuery table name",
+)
+@click.option("--output", type=str, required=True, help="Output path")
+@click.option(
+    "--source",
+    type=click.Choice(["gcs", "bigquery"]),
+    default="gcs",
+    help="The storage location for reading raw prio pings",
+)
+@click.option(
+    "--credentials",
+    type=str,
+    envvar="GOOGLE_APPLICATION_CREDENTIALS",
+    help="Path to google application credentials",
+    required=False,
+)
+def run(date, input, output, source, credentials):
     spark = SparkSession.builder.getOrCreate()
     spark.conf.set("fs.gs.implicit.dir.repair.enable", False)
-    pings = CloudStorageExtract(spark).extract(input, date)
+    if credentials:
+        spark.conf.set("credentialsFile", credentials)
+
+    extract_method = {"gcs": CloudStorageExtract, "bigquery": BigQueryStorageExtract}
+
+    pings = extract_method[source](spark).extract(input, date)
     processed = transform(pings)
     load(processed, output, date)
 

--- a/processor/tests/test_staging.py
+++ b/processor/tests/test_staging.py
@@ -78,12 +78,13 @@ def moz_fx_data_stage_data(tmpdir, prio_ping):
 
 @pytest.fixture()
 def extracted(spark, moz_fx_data_stage_data):
-    return staging.extract(spark, moz_fx_data_stage_data, BASE_DATE)
+    return staging.CloudStorageExtract(spark).extract(moz_fx_data_stage_data, BASE_DATE)
 
 
 def test_extract(extracted):
     assert extracted.count() == NUM_HOURS * NUM_PARTS * NUM_PINGS
     assert not {"id", "prioData"} - set(extracted.columns)
+    assert extracted.schema == staging.ExtractPrioPing.payload_schema
 
 
 def test_estimate_num_partitions(spark):

--- a/processor/tox.ini
+++ b/processor/tox.ini
@@ -14,3 +14,10 @@ addopts = --verbose
 [testenv:black]
 deps = black
 commands = black --check prio-processor tests
+
+[mypy]
+ignore_missing_imports = True
+
+[testenv:mypy]
+deps = mypy
+commands = mypy --config-file tox.ini prio_processor


### PR DESCRIPTION
This PR adds read support from BigQuery by using the spark-bigquery connector. This should run as-is on DataProc as before.

As per https://github.com/mozilla/prio-processor/pull/72#issuecomment-525499075, this is tested in the following way. 

```bash
export GOOGLE_APPLICATION_CREDENTIALS=...
docker run \
    -v $GOOGLE_APPLICATION_CREDENTIALS:/app/.credentials \
    -e GOOGLE_APPLICATION_CREDENTIALS=/app/.credentials \
    -it prio:dev bash

cd processor

prio-processor bootstrap --output tmp
gsutil cp gs://spark-lib/bigquery/spark-bigquery-latest.jar tmp/

spark-submit \
    --jars tmp/spark-bigquery-latest.jar \
    --py-files tmp/prio_processor.egg \
    tmp/runner.py \
        staging \
        --source bigquery \
        --date 2019-08-22 \
        --input moz-fx-data-shared-prod.payload_bytes_decoded.telemetry_telemetry__prio_v4 \
        --output test_data \
        --credentials /app/.credentials
```

```bash
$ tree test_data
test_data
|-- submission_date=2019-08-22
|   |-- server_id=a
|   |   |-- batch_id=content.blocking_blocked-0
|   |   |   `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|   |   |-- batch_id=content.blocking_blocked-1
|   |   |   `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|   |   |-- batch_id=content.blocking_blocked_TESTONLY-0
|   |   |   `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|   |   `-- batch_id=content.blocking_blocked_TESTONLY-1
|   |       `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|   `-- server_id=b
|       |-- batch_id=content.blocking_blocked-0
|       |   `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|       |-- batch_id=content.blocking_blocked-1
|       |   `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|       |-- batch_id=content.blocking_blocked_TESTONLY-0
|       |   `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
|       `-- batch_id=content.blocking_blocked_TESTONLY-1
|           `-- part-00000-c7f8fefe-2454-4a3e-a8d8-8e7853906a14.c000.json
`-- _SUCCESS

11 directories, 9 files
```