### PR TITLE
Update staging job for incremental writes

### DIFF
--- a/processor/prio_processor/staging.py
+++ b/processor/prio_processor/staging.py
@@ -182,6 +182,7 @@ def load(data: DataFrame, output: str, date: str):
 def run(date, input, output, source, credentials):
     spark = SparkSession.builder.getOrCreate()
     spark.conf.set("fs.gs.implicit.dir.repair.enable", False)
+    spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
     if credentials:
         spark.conf.set("credentialsFile", credentials)
 

--- a/processor/tests/test_staging.py
+++ b/processor/tests/test_staging.py
@@ -46,14 +46,14 @@ def prio_ping():
 
 
 @pytest.fixture()
-def moz_fx_data_stage_data(tmpdir, prio_ping):
+def moz_fx_data_stage_data(tmp_path, prio_ping):
     """ Create a bucket that mirrors the google cloud storage sink in the
     ingestion service.
     """
 
     # bucket / re-publisher name / output sink
     sink_dir = Path(
-        tmpdir
+        tmp_path
         / "moz-fx-data-stage-data"
         / "telemetry-decoded_gcs-sink-doctype_prio"
         / "output"
@@ -127,9 +127,9 @@ def test_transform(extracted):
     assert unique_ids == 3 * 8
 
 
-def test_staging_run(moz_fx_data_stage_data, tmpdir):
+def test_staging_run(moz_fx_data_stage_data, tmp_path):
     """
-    To update the directory tree, run `tree` over the `tmpdir` folder.
+    To update the directory tree, run `tree` over the `tmp_path` folder.
 
     ├── moz-fx-data-stage-data
     │   └── telemetry-decoded_gcs-sink-doctype_prio
@@ -161,7 +161,7 @@ def test_staging_run(moz_fx_data_stage_data, tmpdir):
                 └── batch_id=content.blocking_blocked_TESTONLY-1
                     └── part-00000-8bd2216c-55dc-49df-9d95-59349163c9a6.c000.json
     """
-    output = Path(tmpdir / "output")
+    output = Path(tmp_path / "output")
     runner = CliRunner()
     result = runner.invoke(
         staging.run,
@@ -169,9 +169,9 @@ def test_staging_run(moz_fx_data_stage_data, tmpdir):
             "--date",
             BASE_DATE,
             "--input",
-            f"{moz_fx_data_stage_data}",
+            str(moz_fx_data_stage_data),
             "--output",
-            f"{output}",
+            str(output),
         ],
         catch_exceptions=False,
     )
@@ -180,7 +180,7 @@ def test_staging_run(moz_fx_data_stage_data, tmpdir):
     assert len(os.listdir(output)) > 0
 
 
-def test_staging_run_fixed_partitions(moz_fx_data_stage_data, tmpdir, monkeypatch):
+def test_staging_run_fixed_partitions(moz_fx_data_stage_data, tmp_path, monkeypatch):
     """Run the entire pipeline again, except fix the number of partitions when
     repartitioning by range.
 
@@ -212,7 +212,7 @@ def test_staging_run_fixed_partitions(moz_fx_data_stage_data, tmpdir, monkeypatc
         staging, "estimate_num_partitions", mock_estimate_num_partitions
     )
 
-    output = Path(tmpdir / "output")
+    output = Path(tmp_path / "output")
     runner = CliRunner()
     result = runner.invoke(
         staging.run,
@@ -220,9 +220,9 @@ def test_staging_run_fixed_partitions(moz_fx_data_stage_data, tmpdir, monkeypatc
             "--date",
             BASE_DATE,
             "--input",
-            f"{moz_fx_data_stage_data}",
+            str(moz_fx_data_stage_data),
             "--output",
-            f"{output}",
+            str(output),
         ],
         catch_exceptions=False,
     )
@@ -263,8 +263,8 @@ def test_staging_run_fixed_partitions(moz_fx_data_stage_data, tmpdir, monkeypatc
             assert set_a == set_b
 
 
-def test_staging_run_incremental(moz_fx_data_stage_data, tmpdir):
-    output = Path(tmpdir / "output")
+def test_staging_run_incremental(moz_fx_data_stage_data, tmp_path):
+    output = str(tmp_path / "output")
     runner = CliRunner()
     runner.invoke(
         staging.run,
@@ -272,9 +272,9 @@ def test_staging_run_incremental(moz_fx_data_stage_data, tmpdir):
             "--date",
             BASE_DATE,
             "--input",
-            f"{moz_fx_data_stage_data}",
+            str(moz_fx_data_stage_data),
             "--output",
-            f"{output}",
+            output,
         ],
         catch_exceptions=False,
     )
@@ -285,9 +285,9 @@ def test_staging_run_incremental(moz_fx_data_stage_data, tmpdir):
             "--date",
             BASE_DATE_NEXT,
             "--input",
-            f"{moz_fx_data_stage_data}",
+            str(moz_fx_data_stage_data),
             "--output",
-            f"{output}",
+            output,
         ],
         catch_exceptions=False,
     )
@@ -297,8 +297,8 @@ def test_staging_run_incremental(moz_fx_data_stage_data, tmpdir):
     assert dates == [BASE_DATE, BASE_DATE_NEXT]
 
 
-def test_staging_run_idempotent(spark, moz_fx_data_stage_data, tmpdir):
-    output = str(tmpdir / "output")
+def test_staging_run_idempotent(spark, moz_fx_data_stage_data, tmp_path):
+    output = tmp_path / "output"
 
     def run() -> int:
         CliRunner().invoke(
@@ -307,13 +307,13 @@ def test_staging_run_idempotent(spark, moz_fx_data_stage_data, tmpdir):
                 "--date",
                 BASE_DATE,
                 "--input",
-                f"{moz_fx_data_stage_data}",
+                str(moz_fx_data_stage_data),
                 "--output",
-                f"{output}",
+                str(output),
             ],
             catch_exceptions=False,
         )
-        return spark.read.json(output).count()
+        return spark.read.json(str(output)).count()
 
     initial = run()
     rerun = run()


### PR DESCRIPTION
This uses the dynamic partitionOverwriteMode to write new partitions to a dataset without overwriting existing data. I add two tests to ensure that this works as intended, one for testing incremental partitions and another for idempotency. 