### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/processor/setup.py
+++ b/processor/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="prio_processor",
-    version="1.5.0",
+    version="1.6.0",
     description="A processing engine for prio data",
     long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",


### PR DESCRIPTION
This includes a change in #81 that changes the assumption about the format of `BUCKET_*` variables. All buckets must now be prefixed with a protocol.