### PR TITLE
Build prio_processor egg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ ADD . /app
 WORKDIR /app/prio
 RUN make
 
+WORKDIR /app/processor
+RUN python3 setup.py bdist_egg
+
 WORKDIR /app
 RUN pip3 install --upgrade pip && \
         pip3 install -r requirements.txt


### PR DESCRIPTION
This fixes #89 by building the prio_processor egg. This was inadvertently removed in #88.