### PR TITLE
Add dataproc scripts for benchmarking

### DIFF
--- a/bin/dataproc
+++ b/bin/dataproc
@@ -6,9 +6,10 @@
 
 set -e
 
-REGION=us-west1
+REGION=${REGION:-us-west1}
+MACHINE_TYPE=${MACHINE_TYPE:-"n1-standard-4"}
+NUM_WORKERS=${NUM_WORKERS:-0}
 MODULE="prio_processor"
-NUM_WORKERS=${NUM_WORKERS:-1}
 
 function bootstrap() {
     local bucket=$1
@@ -52,8 +53,9 @@ function create_cluster() {
     gcloud beta dataproc clusters create ${cluster_id} \
         --image-version preview-ubuntu18 \
         --enable-component-gateway \
-        --worker-machine-type=n1-standard-4 \
-        --num-secondary-workers ${NUM_WORKERS} \
+        --master-machine-type=$MACHINE_TYPE \
+        --worker-machine-type=$MACHINE_TYPE \
+        --num-workers ${NUM_WORKERS} \
         --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID:-""} \
         --initialization-actions ${bucket}/bootstrap/install-python-requirements.sh \
         --region=${REGION} \

--- a/bin/dataproc
+++ b/bin/dataproc
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# A testing script for verifying the spark-bigquery connector with the existing
+# mozaggregator code. This requires `gcloud` to be configured to point at a
+# sandbox project for reading data from `payload_bytes_decoded`.
+
+set -e
+
+REGION=us-west1
+MODULE="prio_processor"
+NUM_WORKERS=${NUM_WORKERS:-1}
+
+function bootstrap() {
+    local bucket=$1
+
+    # create the initialization script and runner
+    mkdir -p bootstrap
+
+    # create the package artifacts
+    rm -rf dist build
+    python3 setup.py bdist_egg
+    cp dist/${MODULE}*.egg bootstrap/${MODULE}.egg
+    cp requirements.txt bootstrap/
+    tee bootstrap/install-python-requirements.sh >/dev/null <<EOF
+#!/bin/bash
+apt install --yes python-dev libmsgpackc2 libnss3
+gsutil cp gs://${bucket}/bootstrap/requirements.txt .
+pip install -r requirements.txt
+EOF
+    tee bootstrap/processor.py >/dev/null <<EOF
+from prio_processor.spark import commands
+commands.entry_point()
+EOF
+
+    # upload the bootstrap files
+    gsutil rsync -r bootstrap/ "gs://${bucket}/bootstrap/"
+}
+
+function delete_cluster() {
+    local cluster_id=$1
+    gcloud dataproc clusters delete ${cluster_id} --region=${REGION}
+}
+
+function create_cluster() {
+    local cluster_id=$1
+    local bucket=$2
+
+    gcloud beta dataproc clusters create ${cluster_id} \
+        --image-version 1.4 \
+        --enable-component-gateway \
+        --worker-machine-type=n1-standard-8 \
+        --num-secondary-workers ${NUM_WORKERS} \
+        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID} \
+        --initialization-actions gs://${bucket}/bootstrap/install-python-requirements.sh \
+        --region=${REGION} \
+        --max-idle 10m
+}
+
+function submit() {
+    cluster_id=$1
+    bucket=$2
+    # pass the rest of the parameters from the main function
+    shift 2
+    gcloud dataproc jobs submit pyspark \
+        gs://${bucket}/bootstrap/processor.py \
+        --cluster ${cluster_id} \
+        --region ${REGION} \
+        --py-files=gs://${bucket}/bootstrap/${MODULE}.egg \
+        -- "$@"
+}
+
+function main() {
+    cd "$(dirname "$0")/.."
+    bucket=$(gcloud config get-value project)
+    cluster_id="test-prio-processor-${RANDOM}"
+    bootstrap $bucket
+    create_cluster $cluster_id $bucket
+    # does not handle issues where the cluster fails on startup
+    function cleanup() {
+        delete_cluster ${cluster_id}
+    }
+    trap cleanup EXIT
+    submit $cluster_id $bucket "$@"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/bin/dataproc
+++ b/bin/dataproc
@@ -23,8 +23,8 @@ function bootstrap() {
     cp requirements.txt bootstrap/
     tee bootstrap/install-python-requirements.sh >/dev/null <<EOF
 #!/bin/bash
-apt install --yes python-dev libmsgpackc2 libnss3
-gsutil cp gs://${bucket}/bootstrap/requirements.txt .
+apt update && apt install --yes python-dev libmsgpackc2 libnss3
+gsutil cp ${bucket}/bootstrap/requirements.txt .
 pip install -r requirements.txt
 EOF
     tee bootstrap/processor.py >/dev/null <<EOF
@@ -33,7 +33,7 @@ commands.entry_point()
 EOF
 
     # upload the bootstrap files
-    gsutil rsync -r bootstrap/ "gs://${bucket}/bootstrap/"
+    gsutil rsync -r bootstrap/ "${bucket}/bootstrap/"
 }
 
 function delete_cluster() {
@@ -45,13 +45,17 @@ function create_cluster() {
     local cluster_id=$1
     local bucket=$2
 
+    # note that we're using the beta API to enable the component gateway and to
+    # ensure that we can kill the cluster after some time elapses. We use the
+    # preview version (2.x) for Spark 3.0 support. Finally, we need to use
+    # external jars that support scala 2.12.
     gcloud beta dataproc clusters create ${cluster_id} \
-        --image-version 1.4 \
+        --image-version preview-ubuntu18 \
         --enable-component-gateway \
-        --worker-machine-type=n1-standard-8 \
+        --worker-machine-type=n1-standard-4 \
         --num-secondary-workers ${NUM_WORKERS} \
-        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID} \
-        --initialization-actions gs://${bucket}/bootstrap/install-python-requirements.sh \
+        --properties ^#^spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar#spark:spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID:-""} \
+        --initialization-actions ${bucket}/bootstrap/install-python-requirements.sh \
         --region=${REGION} \
         --max-idle 10m
 }
@@ -62,16 +66,16 @@ function submit() {
     # pass the rest of the parameters from the main function
     shift 2
     gcloud dataproc jobs submit pyspark \
-        gs://${bucket}/bootstrap/processor.py \
+        ${bucket}/bootstrap/processor.py \
         --cluster ${cluster_id} \
         --region ${REGION} \
-        --py-files=gs://${bucket}/bootstrap/${MODULE}.egg \
+        --py-files=${bucket}/bootstrap/${MODULE}.egg \
         -- "$@"
 }
 
 function main() {
     cd "$(dirname "$0")/.."
-    bucket=$(gcloud config get-value project)
+    bucket=gs://$(gcloud config get-value project)
     cluster_id="test-prio-processor-${RANDOM}"
     bootstrap $bucket
     create_cluster $cluster_id $bucket

--- a/scripts/test-cli-integration-dataproc
+++ b/scripts/test-cli-integration-dataproc
@@ -6,10 +6,12 @@ cd "$(dirname "$0")/.."
 scripts/create-folder
 
 export NUM_WORKERS=${NUM_WORKERS:-0}
+export MACHINE_TYPE=${MACHINE_TYPE:-"n1-standard-4"}
 BUCKET=${BUCKET?"must include a valid bucket"}
 PREFIX=${PREFIX:-"test-integration-dataproc"}
 WORKING_BUCKET="$BUCKET/$PREFIX"
 ARTIFACT_BUCKET=${ARTIFACT_BUCKET:-$BUCKET/prio-processor-benchmarks}
+CLIENT_BUCKET=${CLIENT_BUCKET:-"$WORKING_BUCKET/client"}
 SERVER_A_BUCKET=${SERVER_A_BUCKET:-"$WORKING_BUCKET/server_a"}
 SERVER_B_BUCKET=${SERVER_B_BUCKET:-"$WORKING_BUCKET/server_b"}
 DATAPROC_CLUSTER_ID=${DATAPROC_CLUSTER_ID:-""}
@@ -106,10 +108,12 @@ if [[ "$SKIP_GENERATE" == "false" ]]; then
         --batch-id ${BATCH_ID} \
         --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
         --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
-        --output-A ${SERVER_A_BUCKET}/raw/ \
-        --output-B ${SERVER_B_BUCKET}/raw/ \
+        --output ${CLIENT_BUCKET} \
         --n-rows ${N_ROWS} \
         --scale ${SCALE}
+
+    gsutil -m rsync -r -d ${CLIENT_BUCKET}/server_id=a/ ${SERVER_A_BUCKET}/raw/
+    gsutil -m rsync -r -d ${CLIENT_BUCKET}/server_id=b/ ${SERVER_B_BUCKET}/raw/
 fi
 
 ###########################################################

--- a/scripts/test-cli-integration-dataproc
+++ b/scripts/test-cli-integration-dataproc
@@ -5,19 +5,24 @@ set -x
 cd "$(dirname "$0")/.."
 scripts/create-folder
 
-# shellcheck source=bin/dataproc
-source bin/dataproc
-
+export NUM_WORKERS=${NUM_WORKERS:-0}
 BUCKET=${BUCKET?"must include a valid bucket"}
 PREFIX=${PREFIX:-"test-integration-dataproc"}
-DATAPROC_CLUSTER_ID=${DATAPROC_CLUSTER_ID:-""}
 WORKING_BUCKET="$BUCKET/$PREFIX"
+ARTIFACT_BUCKET=${ARTIFACT_BUCKET:-$BUCKET/prio-processor-benchmarks}
 SERVER_A_BUCKET=${SERVER_A_BUCKET:-"$WORKING_BUCKET/server_a"}
 SERVER_B_BUCKET=${SERVER_B_BUCKET:-"$WORKING_BUCKET/server_b"}
+DATAPROC_CLUSTER_ID=${DATAPROC_CLUSTER_ID:-""}
+
+export REGION=${REGION:-us-west1}
+export CLOUDSDK_DATAPROC_REGION=$REGION
 
 [[ $BUCKET == "gs://"* ]]
 # check for appropriate access
 gsutil ls $BUCKET
+
+# shellcheck source=bin/dataproc
+source bin/dataproc
 
 # start a dataproc cluster if one doesn't already exist
 if [[ -z "$DATAPROC_CLUSTER_ID" ]]; then
@@ -33,6 +38,27 @@ fi
 
 function run_spark_submit() {
     submit $DATAPROC_CLUSTER_ID $WORKING_BUCKET "$@"
+}
+
+function collect_history() {
+    # collect some history for benchmarking analysis and performance debugging
+    local artifact_bucket=$ARTIFACT_BUCKET
+    local cluster_id=$DATAPROC_CLUSTER_ID
+    local workdir="working"
+
+    mkdir -p $workdir/logs
+    gsutil ls -rl "$WORKING_BUCKET/**" >$workdir/logs/bucket-listing.txt
+    gcloud beta dataproc clusters describe $cluster_id --format json >$workdir/logs/dataproc-clusters-describe.json
+    gcloud beta dataproc jobs list --cluster $cluster_id --format json >$workdir/logs/dataproc-jobs-list.json
+    gsutil -m rsync -r $workdir/ $artifact_bucket/$cluster_id/
+    # copy spark history and yarn logs
+    cluster_uuid=$(jq -r '.clusterUuid' working/logs/dataproc-clusters-describe.json)
+    gsutil -m rsync -r "gs://dataproc-temp*/${cluster_uuid}" $artifact_bucket/$cluster_id/logs
+
+    # copy the raw and processed data for potential analysis
+    gsutil -m rsync -r $WORKING_BUCKET/client/ $artifact_bucket/$cluster_id/client/
+    gsutil -m rsync -r $SERVER_A_BUCKET/processed/ $artifact_bucket/$cluster_id/server_a/processed/
+    gsutil -m rsync -r $SERVER_B_BUCKET/processed/ $artifact_bucket/$cluster_id/server_b/processed/
 }
 
 START_STAGE=${START_STAGE:-0}
@@ -102,7 +128,9 @@ if ((START_STAGE < 2)); then
         --input ${SERVER_A_BUCKET}/raw \
         --output ${SERVER_A_BUCKET}/intermediate/internal/verify1
 
-    gsutil rsync -r \
+    # NOTE: we ensure these buckets are completely synchronized, otherwise it is
+    # possible to for the job to fail during the publishing step.
+    gsutil -m rsync -r -d \
         ${SERVER_A_BUCKET}/intermediate/internal/verify1/ \
         ${SERVER_B_BUCKET}/intermediate/external/verify1/
 
@@ -117,7 +145,7 @@ if ((START_STAGE < 2)); then
         --input ${SERVER_B_BUCKET}/raw \
         --output ${SERVER_B_BUCKET}/intermediate/internal/verify1
 
-    gsutil rsync -r \
+    gsutil -m rsync -r -d \
         ${SERVER_B_BUCKET}/intermediate/internal/verify1/ \
         ${SERVER_A_BUCKET}/intermediate/external/verify1/
 fi
@@ -140,7 +168,7 @@ if ((START_STAGE < 3)); then
         --input-external ${SERVER_A_BUCKET}/intermediate/external/verify1 \
         --output ${SERVER_A_BUCKET}/intermediate/internal/verify2/
 
-    gsutil rsync -r \
+    gsutil -m rsync -r -d \
         ${SERVER_A_BUCKET}/intermediate/internal/verify2/ \
         ${SERVER_B_BUCKET}/intermediate/external/verify2/
 
@@ -157,7 +185,7 @@ if ((START_STAGE < 3)); then
         --input-external ${SERVER_B_BUCKET}/intermediate/external/verify1/ \
         --output ${SERVER_B_BUCKET}/intermediate/internal/verify2/
 
-    gsutil rsync -r \
+    gsutil -m rsync -r -d \
         ${SERVER_B_BUCKET}/intermediate/internal/verify2/ \
         ${SERVER_A_BUCKET}/intermediate/external/verify2/
 fi
@@ -179,7 +207,7 @@ if ((START_STAGE < 4)); then
         --input-external ${SERVER_A_BUCKET}/intermediate/external/verify2 \
         --output ${SERVER_A_BUCKET}/intermediate/internal/aggregate
 
-    gsutil rsync -r \
+    gsutil -m rsync -r -d \
         ${SERVER_A_BUCKET}/intermediate/internal/aggregate/ \
         ${SERVER_B_BUCKET}/intermediate/external/aggregate/
 
@@ -196,7 +224,7 @@ if ((START_STAGE < 4)); then
         --input-external ${SERVER_B_BUCKET}/intermediate/external/verify2 \
         --output ${SERVER_B_BUCKET}/intermediate/internal/aggregate
 
-    gsutil rsync -r \
+    gsutil -m rsync -r -d \
         ${SERVER_B_BUCKET}/intermediate/internal/aggregate/ \
         ${SERVER_A_BUCKET}/intermediate/external/aggregate/
 fi
@@ -217,7 +245,7 @@ time run_spark_submit publish \
     --input-external ${SERVER_A_BUCKET}/intermediate/external/aggregate/*.json \
     --output ${SERVER_A_BUCKET}/processed
 
-gsutil rsync -r -d ${SERVER_A_BUCKET}/processed/ working/server_a/processed/
+gsutil -m rsync -r -d ${SERVER_A_BUCKET}/processed/ working/server_a/processed/
 jq '.' working/server_a/processed/*.json
 [[ $(jq ".error" working/server_a/processed/*.json) -eq 0 ]]
 
@@ -233,6 +261,8 @@ time run_spark_submit publish \
     --input-external ${SERVER_B_BUCKET}/intermediate/external/aggregate/*.json \
     --output ${SERVER_B_BUCKET}/processed
 
-gsutil rsync -r -d ${SERVER_B_BUCKET}/processed/ working/server_b/processed/
+gsutil -m rsync -r -d ${SERVER_B_BUCKET}/processed/ working/server_b/processed/
 jq '.' working/server_b/processed/*.json
 [[ $(jq ".error" working/server_b/processed/*.json) -eq 0 ]]
+
+collect_history

--- a/scripts/test-cli-integration-dataproc
+++ b/scripts/test-cli-integration-dataproc
@@ -1,0 +1,238 @@
+#!/bin/bash
+set -eou pipefail
+set -x
+
+cd "$(dirname "$0")/.."
+scripts/create-folder
+
+# shellcheck source=bin/dataproc
+source bin/dataproc
+
+BUCKET=${BUCKET?"must include a valid bucket"}
+PREFIX=${PREFIX:-"test-integration-dataproc"}
+DATAPROC_CLUSTER_ID=${DATAPROC_CLUSTER_ID:-""}
+WORKING_BUCKET="$BUCKET/$PREFIX"
+SERVER_A_BUCKET=${SERVER_A_BUCKET:-"$WORKING_BUCKET/server_a"}
+SERVER_B_BUCKET=${SERVER_B_BUCKET:-"$WORKING_BUCKET/server_b"}
+
+[[ $BUCKET == "gs://"* ]]
+# check for appropriate access
+gsutil ls $BUCKET
+
+# start a dataproc cluster if one doesn't already exist
+if [[ -z "$DATAPROC_CLUSTER_ID" ]]; then
+    timestamp=$(python3 -c "import datetime as dt, re; print(re.sub('[^\d+]', '', str(dt.datetime.now())))")
+    DATAPROC_CLUSTER_ID="test-prio-processor-${timestamp}"
+    bootstrap $WORKING_BUCKET
+    create_cluster $DATAPROC_CLUSTER_ID $WORKING_BUCKET
+    function cleanup() {
+        delete_cluster ${DATAPROC_CLUSTER_ID}
+    }
+    trap cleanup EXIT
+fi
+
+function run_spark_submit() {
+    submit $DATAPROC_CLUSTER_ID $WORKING_BUCKET "$@"
+}
+
+START_STAGE=${START_STAGE:-0}
+SKIP_GENERATE=${SKIP_GENERATE:-"false"}
+if ((START_STAGE > 0)); then
+    SKIP_GENERATE="true"
+fi
+
+if [[ "$SKIP_GENERATE" == "false" ]]; then
+    # generate some configuration
+    key_a=$(prio keygen)
+    key_b=$(prio keygen)
+    shared=$(prio shared-seed)
+    N_DATA=${N_DATA:-128}
+    N_ROWS=${N_ROWS:-1000}
+    SCALE=${SCALE:-1}
+    BATCH_ID=${BATCH_ID:-"test"}
+
+    echo $key_a | jq >"working/server_a_keys.json"
+    echo $key_b | jq >"working/server_b_keys.json"
+    echo $shared | jq >"working/shared_seed.json"
+    cat <<EOF >working/config.json
+{
+    "n_data": $N_DATA,
+    "batch_id": "$BATCH_ID"
+}
+EOF
+else
+    key_a=$(jq '.' working/server_a_keys.json)
+    key_b=$(jq '.' working/server_b_keys.json)
+    shared=$(jq '.' working/shared_seed.json)
+fi
+
+N_DATA=$(jq -r ".n_data" working/config.json)
+BATCH_ID=$(jq -r ".batch_id" working/config.json)
+SHARED_SECRET=${SHARED_SECRET:-$(jq -r ".shared_seed" <<<$shared)}
+SERVER_A_PUBLIC_KEY=${SERVER_A_PUBLIC_KEY:-$(jq -r ".public_key" <<<$key_a)}
+SERVER_B_PUBLIC_KEY=${SERVER_B_PUBLIC_KEY:-$(jq -r ".public_key" <<<$key_b)}
+SERVER_A_PRIVATE_KEY=${SERVER_A_PRIVATE_KEY:-$(jq -r ".private_key" <<<$key_a)}
+SERVER_B_PRIVATE_KEY=${SERVER_B_PRIVATE_KEY:-$(jq -r ".private_key" <<<$key_b)}
+
+if [[ "$SKIP_GENERATE" == "false" ]]; then
+    time run_spark_submit generate \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
+        --output-A ${SERVER_A_BUCKET}/raw/ \
+        --output-B ${SERVER_B_BUCKET}/raw/ \
+        --n-rows ${N_ROWS} \
+        --scale ${SCALE}
+fi
+
+###########################################################
+# verify1
+###########################################################
+
+if ((START_STAGE < 2)); then
+    time run_spark_submit verify1 \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --server-id A \
+        --private-key-hex ${SERVER_A_PRIVATE_KEY} \
+        --shared-secret $SHARED_SECRET \
+        --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
+        --input ${SERVER_A_BUCKET}/raw \
+        --output ${SERVER_A_BUCKET}/intermediate/internal/verify1
+
+    gsutil rsync -r \
+        ${SERVER_A_BUCKET}/intermediate/internal/verify1/ \
+        ${SERVER_B_BUCKET}/intermediate/external/verify1/
+
+    time run_spark_submit verify1 \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --server-id B \
+        --private-key-hex ${SERVER_B_PRIVATE_KEY} \
+        --shared-secret $SHARED_SECRET \
+        --public-key-hex-internal ${SERVER_B_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_A_PUBLIC_KEY} \
+        --input ${SERVER_B_BUCKET}/raw \
+        --output ${SERVER_B_BUCKET}/intermediate/internal/verify1
+
+    gsutil rsync -r \
+        ${SERVER_B_BUCKET}/intermediate/internal/verify1/ \
+        ${SERVER_A_BUCKET}/intermediate/external/verify1/
+fi
+
+###########################################################
+# verify2
+###########################################################
+
+if ((START_STAGE < 3)); then
+    time run_spark_submit verify2 \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --server-id A \
+        --private-key-hex ${SERVER_A_PRIVATE_KEY} \
+        --shared-secret $SHARED_SECRET \
+        --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
+        --input ${SERVER_A_BUCKET}/raw \
+        --input-internal ${SERVER_A_BUCKET}/intermediate/internal/verify1 \
+        --input-external ${SERVER_A_BUCKET}/intermediate/external/verify1 \
+        --output ${SERVER_A_BUCKET}/intermediate/internal/verify2/
+
+    gsutil rsync -r \
+        ${SERVER_A_BUCKET}/intermediate/internal/verify2/ \
+        ${SERVER_B_BUCKET}/intermediate/external/verify2/
+
+    time run_spark_submit verify2 \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --server-id B \
+        --private-key-hex ${SERVER_B_PRIVATE_KEY} \
+        --shared-secret $SHARED_SECRET \
+        --public-key-hex-internal ${SERVER_B_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_A_PUBLIC_KEY} \
+        --input ${SERVER_B_BUCKET}/raw \
+        --input-internal ${SERVER_B_BUCKET}/intermediate/internal/verify1/ \
+        --input-external ${SERVER_B_BUCKET}/intermediate/external/verify1/ \
+        --output ${SERVER_B_BUCKET}/intermediate/internal/verify2/
+
+    gsutil rsync -r \
+        ${SERVER_B_BUCKET}/intermediate/internal/verify2/ \
+        ${SERVER_A_BUCKET}/intermediate/external/verify2/
+fi
+###########################################################
+# aggregate
+###########################################################
+
+if ((START_STAGE < 4)); then
+    time run_spark_submit aggregate \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --server-id A \
+        --private-key-hex ${SERVER_A_PRIVATE_KEY} \
+        --shared-secret $SHARED_SECRET \
+        --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
+        --input ${SERVER_A_BUCKET}/raw \
+        --input-internal ${SERVER_A_BUCKET}/intermediate/internal/verify2 \
+        --input-external ${SERVER_A_BUCKET}/intermediate/external/verify2 \
+        --output ${SERVER_A_BUCKET}/intermediate/internal/aggregate
+
+    gsutil rsync -r \
+        ${SERVER_A_BUCKET}/intermediate/internal/aggregate/ \
+        ${SERVER_B_BUCKET}/intermediate/external/aggregate/
+
+    time run_spark_submit aggregate \
+        --n-data ${N_DATA} \
+        --batch-id ${BATCH_ID} \
+        --server-id B \
+        --private-key-hex ${SERVER_B_PRIVATE_KEY} \
+        --shared-secret $SHARED_SECRET \
+        --public-key-hex-internal ${SERVER_B_PUBLIC_KEY} \
+        --public-key-hex-external ${SERVER_A_PUBLIC_KEY} \
+        --input ${SERVER_B_BUCKET}/raw \
+        --input-internal ${SERVER_B_BUCKET}/intermediate/internal/verify2 \
+        --input-external ${SERVER_B_BUCKET}/intermediate/external/verify2 \
+        --output ${SERVER_B_BUCKET}/intermediate/internal/aggregate
+
+    gsutil rsync -r \
+        ${SERVER_B_BUCKET}/intermediate/internal/aggregate/ \
+        ${SERVER_A_BUCKET}/intermediate/external/aggregate/
+fi
+
+###########################################################
+# publish
+###########################################################
+
+time run_spark_submit publish \
+    --n-data ${N_DATA} \
+    --batch-id ${BATCH_ID} \
+    --server-id A \
+    --private-key-hex ${SERVER_A_PRIVATE_KEY} \
+    --shared-secret $SHARED_SECRET \
+    --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
+    --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
+    --input-internal ${SERVER_A_BUCKET}/intermediate/internal/aggregate/*.json \
+    --input-external ${SERVER_A_BUCKET}/intermediate/external/aggregate/*.json \
+    --output ${SERVER_A_BUCKET}/processed
+
+gsutil rsync -r -d ${SERVER_A_BUCKET}/processed/ working/server_a/processed/
+jq '.' working/server_a/processed/*.json
+[[ $(jq ".error" working/server_a/processed/*.json) -eq 0 ]]
+
+time run_spark_submit publish \
+    --n-data ${N_DATA} \
+    --batch-id ${BATCH_ID} \
+    --server-id B \
+    --private-key-hex ${SERVER_B_PRIVATE_KEY} \
+    --shared-secret $SHARED_SECRET \
+    --public-key-hex-internal ${SERVER_B_PUBLIC_KEY} \
+    --public-key-hex-external ${SERVER_A_PUBLIC_KEY} \
+    --input-internal ${SERVER_B_BUCKET}/intermediate/internal/aggregate/*.json \
+    --input-external ${SERVER_B_BUCKET}/intermediate/external/aggregate/*.json \
+    --output ${SERVER_B_BUCKET}/processed
+
+gsutil rsync -r -d ${SERVER_B_BUCKET}/processed/ working/server_b/processed/
+jq '.' working/server_b/processed/*.json
+[[ $(jq ".error" working/server_b/processed/*.json) -eq 0 ]]

--- a/scripts/test-cli-integration-dataproc
+++ b/scripts/test-cli-integration-dataproc
@@ -5,63 +5,72 @@ set -x
 cd "$(dirname "$0")/.."
 scripts/create-folder
 
+# test parameters for data size
+N_DATA=${N_DATA:-128}
+N_ROWS=${N_ROWS:-1000}
+SCALE=${SCALE:-1}
+BATCH_ID=${BATCH_ID:-"test"}
+
+# parameters for computational performance, exported for dataproc script
 export NUM_WORKERS=${NUM_WORKERS:-0}
 export MACHINE_TYPE=${MACHINE_TYPE:-"n1-standard-4"}
+
+timestamp=$(python3 -c "import datetime as dt, re; print(re.sub('[^\d+]', '', str(dt.datetime.now()))[:14])")
+BENCHMARK_NAME="${BATCH_ID}-${N_DATA}-$((N_ROWS * SCALE))-${MACHINE_TYPE}-${NUM_WORKERS}-${timestamp}"
+echo "running benchmark $BENCHMARK_NAME"
+
+# set up the storage locations for working and artifact
 BUCKET=${BUCKET?"must include a valid bucket"}
-PREFIX=${PREFIX:-"test-integration-dataproc"}
-WORKING_BUCKET="$BUCKET/$PREFIX"
-ARTIFACT_BUCKET=${ARTIFACT_BUCKET:-$BUCKET/prio-processor-benchmarks}
+PREFIX=${PREFIX:-"data"}
+
+ARTIFACT_BUCKET="$BUCKET/$PREFIX/benchmark/$BENCHMARK_NAME"
+# relative to the current working directory
+WORKING_FOLDER=${WORKING_FOLDER:-$PREFIX/$BENCHMARK_NAME}
+WORKING_BUCKET="$BUCKET/$PREFIX/working/$BENCHMARK_NAME"
 CLIENT_BUCKET=${CLIENT_BUCKET:-"$WORKING_BUCKET/client"}
 SERVER_A_BUCKET=${SERVER_A_BUCKET:-"$WORKING_BUCKET/server_a"}
 SERVER_B_BUCKET=${SERVER_B_BUCKET:-"$WORKING_BUCKET/server_b"}
-DATAPROC_CLUSTER_ID=${DATAPROC_CLUSTER_ID:-""}
 
+# set up so `gcloud dataproc` commands don't require `--region` option
 export REGION=${REGION:-us-west1}
 export CLOUDSDK_DATAPROC_REGION=$REGION
 
-[[ $BUCKET == "gs://"* ]]
-# check for appropriate access
-gsutil ls $BUCKET
-
-# shellcheck source=bin/dataproc
-source bin/dataproc
-
-# start a dataproc cluster if one doesn't already exist
-if [[ -z "$DATAPROC_CLUSTER_ID" ]]; then
-    timestamp=$(python3 -c "import datetime as dt, re; print(re.sub('[^\d+]', '', str(dt.datetime.now())))")
-    DATAPROC_CLUSTER_ID="test-prio-processor-${timestamp}"
-    bootstrap $WORKING_BUCKET
-    create_cluster $DATAPROC_CLUSTER_ID $WORKING_BUCKET
-    function cleanup() {
-        delete_cluster ${DATAPROC_CLUSTER_ID}
-    }
-    trap cleanup EXIT
-fi
-
 function run_spark_submit() {
-    submit $DATAPROC_CLUSTER_ID $WORKING_BUCKET "$@"
+    submit $BENCHMARK_NAME $WORKING_BUCKET "$@"
 }
 
 function collect_history() {
     # collect some history for benchmarking analysis and performance debugging
     local artifact_bucket=$ARTIFACT_BUCKET
-    local cluster_id=$DATAPROC_CLUSTER_ID
-    local workdir="working"
+    local cluster_id=$BENCHMARK_NAME
+    local working_folder=$WORKING_FOLDER
 
-    mkdir -p $workdir/logs
-    gsutil ls -rl "$WORKING_BUCKET/**" >$workdir/logs/bucket-listing.txt
-    gcloud beta dataproc clusters describe $cluster_id --format json >$workdir/logs/dataproc-clusters-describe.json
-    gcloud beta dataproc jobs list --cluster $cluster_id --format json >$workdir/logs/dataproc-jobs-list.json
-    gsutil -m rsync -r $workdir/ $artifact_bucket/$cluster_id/
+    mkdir -p $working_folder/logs
+    gsutil ls -rl "$WORKING_BUCKET/**" >$working_folder/logs/bucket-listing.txt
+    gcloud beta dataproc clusters describe $cluster_id --format json >$working_folder/logs/dataproc-clusters-describe.json
+    gcloud beta dataproc jobs list --cluster $cluster_id --format json >$working_folder/logs/dataproc-jobs-list.json
+    gsutil -m rsync -r $working_folder/ $artifact_bucket/
+
     # copy spark history and yarn logs
-    cluster_uuid=$(jq -r '.clusterUuid' working/logs/dataproc-clusters-describe.json)
-    gsutil -m rsync -r "gs://dataproc-temp*/${cluster_uuid}" $artifact_bucket/$cluster_id/logs
+    cluster_uuid=$(jq -r '.clusterUuid' $working_folder/logs/dataproc-clusters-describe.json)
+    gsutil -m rsync -r "gs://dataproc-temp*/${cluster_uuid}" $artifact_bucket/logs
 
     # copy the raw and processed data for potential analysis
-    gsutil -m rsync -r $WORKING_BUCKET/client/ $artifact_bucket/$cluster_id/client/
-    gsutil -m rsync -r $SERVER_A_BUCKET/processed/ $artifact_bucket/$cluster_id/server_a/processed/
-    gsutil -m rsync -r $SERVER_B_BUCKET/processed/ $artifact_bucket/$cluster_id/server_b/processed/
+    gsutil -m rsync -r $WORKING_BUCKET/client/ $artifact_bucket/client/
+    gsutil -m rsync -r $SERVER_A_BUCKET/processed/ $artifact_bucket/server_a/processed/
+    gsutil -m rsync -r $SERVER_B_BUCKET/processed/ $artifact_bucket/server_b/processed/
 }
+
+# check local installion of prio commandline
+prio --help
+
+[[ $BUCKET == "gs://"* ]]
+
+# check for appropriate access
+gsutil ls $BUCKET
+
+# make the working folder
+mkdir -p $WORKING_FOLDER
 
 START_STAGE=${START_STAGE:-0}
 SKIP_GENERATE=${SKIP_GENERATE:-"false"}
@@ -74,33 +83,46 @@ if [[ "$SKIP_GENERATE" == "false" ]]; then
     key_a=$(prio keygen)
     key_b=$(prio keygen)
     shared=$(prio shared-seed)
-    N_DATA=${N_DATA:-128}
-    N_ROWS=${N_ROWS:-1000}
-    SCALE=${SCALE:-1}
-    BATCH_ID=${BATCH_ID:-"test"}
 
-    echo $key_a | jq >"working/server_a_keys.json"
-    echo $key_b | jq >"working/server_b_keys.json"
-    echo $shared | jq >"working/shared_seed.json"
-    cat <<EOF >working/config.json
+    echo $key_a >"$WORKING_FOLDER/server_a_keys.json"
+    echo $key_b >"$WORKING_FOLDER/server_b_keys.json"
+    echo $shared >"$WORKING_FOLDER/shared_seed.json"
+    cat <<EOF >"$WORKING_FOLDER/config.json"
 {
     "n_data": $N_DATA,
-    "batch_id": "$BATCH_ID"
+    "batch_id": "$BATCH_ID",
+    "n_rows": $N_ROWS,
+    "scale": $SCALE,
+    "machine_type": "$MACHINE_TYPE",
+    "num_workers": $NUM_WORKERS
 }
 EOF
 else
-    key_a=$(jq '.' working/server_a_keys.json)
-    key_b=$(jq '.' working/server_b_keys.json)
-    shared=$(jq '.' working/shared_seed.json)
+    key_a=$(jq '.' $WORKING_FOLDER/server_a_keys.json)
+    key_b=$(jq '.' $WORKING_FOLDER/server_b_keys.json)
+    shared=$(jq '.' $WORKING_FOLDER/shared_seed.json)
 fi
 
-N_DATA=$(jq -r ".n_data" working/config.json)
-BATCH_ID=$(jq -r ".batch_id" working/config.json)
+N_DATA=$(jq -r ".n_data" $WORKING_FOLDER/config.json)
+BATCH_ID=$(jq -r ".batch_id" $WORKING_FOLDER/config.json)
 SHARED_SECRET=${SHARED_SECRET:-$(jq -r ".shared_seed" <<<$shared)}
 SERVER_A_PUBLIC_KEY=${SERVER_A_PUBLIC_KEY:-$(jq -r ".public_key" <<<$key_a)}
 SERVER_B_PUBLIC_KEY=${SERVER_B_PUBLIC_KEY:-$(jq -r ".public_key" <<<$key_b)}
 SERVER_A_PRIVATE_KEY=${SERVER_A_PRIVATE_KEY:-$(jq -r ".private_key" <<<$key_a)}
 SERVER_B_PRIVATE_KEY=${SERVER_B_PRIVATE_KEY:-$(jq -r ".private_key" <<<$key_b)}
+
+# shellcheck source=bin/dataproc
+source bin/dataproc
+
+# start a dataproc cluster if one doesn't already exist
+if ! gcloud dataproc clusters describe $BENCHMARK_NAME; then
+    bootstrap $WORKING_BUCKET
+    create_cluster $BENCHMARK_NAME $WORKING_BUCKET
+    function cleanup() {
+        delete_cluster ${BENCHMARK_NAME}
+    }
+    trap cleanup EXIT
+fi
 
 if [[ "$SKIP_GENERATE" == "false" ]]; then
     time run_spark_submit generate \

--- a/scripts/test-cli-integration-spark
+++ b/scripts/test-cli-integration-spark
@@ -60,10 +60,12 @@ if [[ "$SKIP_GENERATE" == "false" ]]; then
         --batch-id ${BATCH_ID} \
         --public-key-hex-internal ${SERVER_A_PUBLIC_KEY} \
         --public-key-hex-external ${SERVER_B_PUBLIC_KEY} \
-        --output-A ${SERVER_A_BUCKET}/raw/ \
-        --output-B ${SERVER_B_BUCKET}/raw/ \
+        --output $CLIENT_BUCKET \
         --n-rows ${N_ROWS} \
         --scale ${SCALE}
+
+    rsync -r --delete $CLIENT_BUCKET/server_id=a/ $SERVER_A_BUCKET/raw/
+    rsync -r --delete $CLIENT_BUCKET/server_id=b/ $SERVER_B_BUCKET/raw/
 fi
 
 ###########################################################

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prio_processor",
-    version="2.1.1",
+    version="2.2.0",
     description="A processing engine for prio data",
     long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="prio_processor",
@@ -23,5 +23,5 @@ setup(
         "prio >= 1.1",
         "pandas",
     ],
-    packages=["prio_processor"],
+    packages=find_packages(),
 )


### PR DESCRIPTION
I ran the following commands:

```bash
BUCKET=gs://prio-processor-benchmark  N_DATA=32 N_ROWS=2500 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=32 N_ROWS=5000 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=32 N_ROWS=7500 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=32 N_ROWS=10000 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc

BUCKET=gs://prio-processor-benchmark  N_DATA=64 N_ROWS=2500 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=64 N_ROWS=5000 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=64 N_ROWS=7500 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=64 N_ROWS=10000 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc

BUCKET=gs://prio-processor-benchmark  N_DATA=128 N_ROWS=2500 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=128 N_ROWS=5000 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=128 N_ROWS=7500 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
BUCKET=gs://prio-processor-benchmark  N_DATA=128 N_ROWS=10000 MACHINE_TYPE=n1-standard-16 NUM_WORKERS=0 ./scripts/test-cli-integration-dataproc
```

The jobs have a working directory under `gs://prio-processor-benchmark/data/working` and is moved to `gs://prio-processor-benchmark/data/benchmark` on success.

```bash
% gsutil ls gs://prio-processor-benchmark/data/benchmark
gs://prio-processor-benchmark/data/benchmark/test-128-10000-n1-standard-16-0-20200824003830/
gs://prio-processor-benchmark/data/benchmark/test-128-2500-n1-standard-16-0-20200824004122/
gs://prio-processor-benchmark/data/benchmark/test-128-5000-n1-standard-16-0-20200824004027/
gs://prio-processor-benchmark/data/benchmark/test-128-7500-n1-standard-16-0-20200824003959/
gs://prio-processor-benchmark/data/benchmark/test-32-10000-n1-standard-16-0-20200824000750396484/
gs://prio-processor-benchmark/data/benchmark/test-32-2500-n1-standard-16-0-20200823234848898312/
gs://prio-processor-benchmark/data/benchmark/test-32-5000-n1-standard-16-0-20200824000733009240/
gs://prio-processor-benchmark/data/benchmark/test-32-7500-n1-standard-16-0-20200824000741901558/
gs://prio-processor-benchmark/data/benchmark/test-64-10000-n1-standard-16-0-20200824001934367765/
gs://prio-processor-benchmark/data/benchmark/test-64-2500-n1-standard-16-0-20200824001916185249/
gs://prio-processor-benchmark/data/benchmark/test-64-5000-n1-standard-16-0-20200824001922568161/
gs://prio-processor-benchmark/data/benchmark/test-64-7500-n1-standard-16-0-20200824001928540460/
```

The naming convention changes near the end because the original 20 character timestamp caused the name to go beyond the length of the allowable dataproc cluster name. This generates output as follows in GCS, which is copied locally for log analysis via Spark.

```
../data/test-128-10000-n1-standard-16-0-20200824003830
├── client
│   ├── _SUCCESS
│   ├── server_id=a
│   │   └── part-00000-faab898b-0423-4e16-813b-560ac71d754d.c000.json
│   └── server_id=b
│       └── part-00000-faab898b-0423-4e16-813b-560ac71d754d.c000.json
├── config.json
├── logs
│   ├── bucket-listing.txt
│   ├── dataproc-clusters-describe.json
│   ├── dataproc-jobs-list.json
│   ├── spark-job-history
│   │   ├── application_1598254988496_0002
│   │   ├── application_1598254988496_0003
│   │   ├── application_1598254988496_0004
│   │   ├── application_1598254988496_0005
│   │   ├── application_1598254988496_0006
│   │   ├── application_1598254988496_0007
│   │   ├── application_1598254988496_0008
│   │   ├── application_1598254988496_0009
│   │   └── application_1598254988496_0010
│   └── yarn-logs
│       └── root
│           └── logs-tfile
│               ├── application_1598254988496_0002
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0003
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0004
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0005
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0006
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0007
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0008
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               ├── application_1598254988496_0009
│               │   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
│               └── application_1598254988496_0010
│                   └── test-128-10000-n1-standard-16-0-20200824003830-m.c.amiyaguchi-dev.internal_8026
├── server_a
│   └── processed
│       ├── _SUCCESS
│       └── part-00000-59df14d1-6b8d-4a64-bee5-6c750866aed7-c000.json
├── server_a_keys.json
├── server_b
│   └── processed
│       ├── _SUCCESS
│       └── part-00000-464d4322-471b-49c8-bff6-caa2f5e3524a-c000.json
├── server_b_keys.json
└── shared_seed.json

21 directories, 32 files
```