### PR TITLE
Upgrade dependencies, add mc, and jars for s3a connector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY requirements.txt requirements-dev.txt ./
 
 ENV PATH="$PATH:~/.local/bin"
 RUN python3 -m ensurepip && \
-        pip3 install --upgrade pip && \
+        pip3 install --upgrade pip wheel && \
         pip3 install -r requirements.txt -r requirements-dev.txt
 
 ENV SPARK_HOME=/usr/local/lib/python3.6/site-packages/pyspark
@@ -44,9 +44,13 @@ ENV PYSPARK_PYTHON=python3
 # may be more appropriate to add to the image build instead of fetching at
 # runtime.
 # https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage
-RUN gsutil cp gs://hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar "${SPARK_HOME}/jars"
-RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar
-RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar
+RUN gsutil cp gs://hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar "${SPARK_HOME}/jars"
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.0/hadoop-aws-3.2.0.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.375/aws-java-sdk-bundle-1.11.375.jar
+
+# Use the MinIO client for cross platform behavior, even with self-hosting
+RUN wget --directory-prefix /usr/local/bin https://dl.min.io/client/mc/release/linux-amd64/mc
+RUN chmod +x /usr/local/bin/mc
 
 ADD . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,9 @@ RUN python3 -m ensurepip && \
 ENV SPARK_HOME=/usr/local/lib/python3.6/site-packages/pyspark
 ENV PYSPARK_PYTHON=python3
 
-# Install libraries for interacting with cloud storage.
-# NOTE: this is only necessary when running outside of dataproc to use GCS
-# directly. A similar approach would need to be done to acommodate s3a. This
-# may be more appropriate to add to the image build instead of fetching at
-# runtime.
+# Install libraries for interacting with cloud storage. We utilize the s3a
+# adaptor for cross-cloud compatibility, but use of the gcs connector may be
+# more performant when running directly in GCP.
 # https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage
 RUN gsutil cp gs://hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar "${SPARK_HOME}/jars"
 RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.0/hadoop-aws-3.2.0.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN yum install -y epel-release \
         parallel \
         which \
         tree \
+        wget \
         && yum clean all \
         && rm -rf /var/cache/yum
 
@@ -44,6 +45,8 @@ ENV PYSPARK_PYTHON=python3
 # runtime.
 # https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage
 RUN gsutil cp gs://hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar "${SPARK_HOME}/jars"
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar
+RUN wget --directory-prefix $SPARK_HOME/jars/ https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar
 
 ADD . /app
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,29 +4,62 @@
 #
 #    pip-compile requirements-dev.in
 #
-attrs==19.3.0             # via pytest
-click==7.1.2              # via mkdocs, nltk
-future==0.18.2            # via lunr
-importlib-metadata==1.7.0  # via markdown, pluggy, pytest
-iniconfig==1.0.1          # via pytest
-jinja2==2.11.2            # via mkdocs
-joblib==0.17.0            # via nltk
-livereload==2.6.3         # via mkdocs
-lunr[languages]==0.5.8    # via mkdocs
-markdown==3.3.2           # via mkdocs
-markupsafe==1.1.1         # via jinja2
+attrs==19.3.0
+    # via
+    #   -c requirements.txt
+    #   pytest
+click==7.1.2
+    # via
+    #   -c requirements.txt
+    #   mkdocs
+    #   nltk
+future==0.18.2
+    # via lunr
+iniconfig==1.0.1
+    # via pytest
+jinja2==2.11.2
+    # via mkdocs
+joblib==0.17.0
+    # via nltk
+livereload==2.6.3
+    # via mkdocs
+lunr[languages]==0.5.8
+    # via mkdocs
+markdown==3.3.2
+    # via mkdocs
+markupsafe==1.1.1
+    # via jinja2
 mkdocs==1.1.2
-more-itertools==8.4.0     # via pytest
-nltk==3.5                 # via lunr
-packaging==20.4           # via pytest
-pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
-pyparsing==2.4.7          # via packaging
+    # via -r requirements-dev.in
+more-itertools==8.4.0
+    # via pytest
+nltk==3.5
+    # via lunr
+packaging==20.4
+    # via pytest
+pluggy==0.13.1
+    # via pytest
+py==1.9.0
+    # via pytest
+pyparsing==2.4.7
+    # via packaging
 pytest==6.0.1
-pyyaml==5.3.1             # via mkdocs
-regex==2020.10.23         # via nltk
-six==1.15.0               # via livereload, lunr, packaging
-toml==0.10.1              # via pytest
-tornado==6.0.4            # via livereload, mkdocs
-tqdm==4.50.2              # via nltk
-zipp==3.1.0               # via importlib-metadata
+    # via -r requirements-dev.in
+pyyaml==5.3.1
+    # via mkdocs
+regex==2020.10.23
+    # via nltk
+six==1.15.0
+    # via
+    #   -c requirements.txt
+    #   livereload
+    #   lunr
+    #   packaging
+toml==0.10.1
+    # via pytest
+tornado==6.0.4
+    # via
+    #   livereload
+    #   mkdocs
+tqdm==4.50.2
+    # via nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,39 @@
 #
 #    pip-compile
 #
-attrs==19.3.0             # via jsonschema
-click==7.1.2              # via prio_processor (setup.py)
-jsonschema==3.2.0         # via prio_processor (setup.py)
-numpy==1.19.1             # via pandas, pyarrow
-pandas==1.1.0             # via prio_processor (setup.py), pyspark
-prio==1.1                 # via prio_processor (setup.py)
-py4j==0.10.9              # via pyspark
-pyarrow==1.0.0            # via pyspark
-pyrsistent==0.16.0        # via jsonschema
-pyspark[sql]==3.0.0       # via prio_processor (setup.py)
-python-dateutil==2.8.1    # via pandas
-pytz==2020.1              # via pandas
-six==1.15.0               # via jsonschema, pyrsistent, python-dateutil
+attrs==19.3.0
+    # via jsonschema
+click==7.1.2
+    # via prio_processor (setup.py)
+jsonschema==3.2.0
+    # via prio_processor (setup.py)
+numpy==1.19.1
+    # via
+    #   pandas
+    #   pyarrow
+pandas==1.1.0
+    # via
+    #   prio_processor (setup.py)
+    #   pyspark
+prio==1.1
+    # via prio_processor (setup.py)
+py4j==0.10.9
+    # via pyspark
+pyarrow==1.0.0
+    # via pyspark
+pyrsistent==0.16.0
+    # via jsonschema
+pyspark[sql]==3.1.1
+    # via prio_processor (setup.py)
+python-dateutil==2.8.1
+    # via pandas
+pytz==2020.1
+    # via pandas
+six==1.15.0
+    # via
+    #   jsonschema
+    #   pyrsistent
+    #   python-dateutil
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     },
     install_requires=[
         "click",
-        "pyspark[sql] >= 3.0.0",
+        # starting pyspark 3.1, the default hadoop distribution is 3.2
+        "pyspark[sql] ~= 3.1",
         "jsonschema",
         "prio >= 1.1",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prio_processor",
-    version="3.0.1",
+    version="3.1.0",
     description="A processing engine for prio data",
     long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",


### PR DESCRIPTION
This bumps the dependencies for the container and adds connectors for s3a compatibility. The idea is that s3a will be the only supported connector in the spark job starting in the 4.0 release, which means a bunch of backwards incompatible changes such as requiring hmac keys (e.g. access key and access secret) and using `mc` instead of gsutil. On the other hand, this will make it easier to self-host. 