### PR TITLE
Use private bucket for internal intermediate results

### DIFF
--- a/bin/process
+++ b/bin/process
@@ -108,7 +108,7 @@ function verify1() {
     # Read the shares for this server and start verification with the external server.
 
     local input="${BUCKET_INTERNAL_INGEST}/${INTERNAL_PREFIX}/raw/shares"
-    local output_internal="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/internal/verify1"
+    local output_internal="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/intermediate/internal/verify1"
     local output_external="${BUCKET_EXTERNAL_SHARED}/${EXTERNAL_PREFIX}/intermediate/external/verify1"
 
     wait_for_data "${input}/_SUCCESS"
@@ -138,9 +138,9 @@ function verify2() {
     # Verify that the shares are well-formed by proving a secret-shared non-interactive proof.
 
     local input="${BUCKET_INTERNAL_INGEST}/${INTERNAL_PREFIX}/raw/shares"
-    local input_internal="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/internal/verify1"
+    local input_internal="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/intermediate/internal/verify1"
     local input_external="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/external/verify1"
-    local output_internal="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/internal/verify2"
+    local output_internal="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/intermediate/internal/verify2"
     local output_external="${BUCKET_EXTERNAL_SHARED}/${EXTERNAL_PREFIX}/intermediate/external/verify2"
 
     wait_for_data "${input_external}/_SUCCESS"
@@ -168,9 +168,9 @@ function aggregate() {
     # Accumulate well-formed shares.
 
     local input="${BUCKET_INTERNAL_INGEST}/${INTERNAL_PREFIX}/raw/shares"
-    local input_internal="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/internal/verify2"
+    local input_internal="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/intermediate/internal/verify2"
     local input_external="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/external/verify2"
-    local output_internal="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/internal/aggregate"
+    local output_internal="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/intermediate/internal/aggregate"
     local output_external="${BUCKET_EXTERNAL_SHARED}/${EXTERNAL_PREFIX}/intermediate/external/aggregate"
 
     wait_for_data "${input_external}/_SUCCESS"
@@ -197,7 +197,7 @@ function aggregate() {
 function publish() {
     # Publish the aggregated shares.
 
-    local input_internal="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/internal/aggregate"
+    local input_internal="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/intermediate/internal/aggregate"
     local input_external="${BUCKET_INTERNAL_SHARED}/${INTERNAL_PREFIX}/intermediate/external/aggregate"
     local output="${BUCKET_INTERNAL_PRIVATE}/${INTERNAL_PREFIX}/processed/publish"
 

--- a/deployment/testing-v4/LISTING.md
+++ b/deployment/testing-v4/LISTING.md
@@ -8,46 +8,91 @@ objects stored across the the two servers.
 ### `gs://a-ingest-d70d758a4b28a791/`
 
 ```
-       524  2021-04-26T21:44:30Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/batch_id=bad-id/.part-00000-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json.crc
-        16  2021-04-26T21:44:30Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/batch_id=bad-id/.part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json.crc
-     66033  2021-04-26T21:44:30Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/batch_id=bad-id/part-00000-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json
-       667  2021-04-26T21:44:30Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/batch_id=bad-id/part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json
-     51384  2021-04-26T21:44:30Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/batch_id=content.blocking_blocked_TESTONLY-0/.part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json.crc
-   6575652  2021-04-26T21:44:32Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/batch_id=content.blocking_blocked_TESTONLY-0/part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json
-         0  2021-04-26T21:44:33Z  gs://a-ingest-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/raw/shares/_SUCCESS
+.
+└── gs:
+    └── a-ingest-d70d758a4b28a791
+        └── test-app
+            └── v1
+                └── C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B
+                    └── test-app
+                        └── 2021-04-27
+                            └── raw
+                                └── shares
+                                    ├── _SUCCESS
+                                    ├── batch_id=bad-id
+                                    │   └── part-00000-90dbdd61-fb92-4fc0-839f-94e498118b03.c000.json
+                                    └── batch_id=content.blocking_blocked_TESTONLY-0
+                                        └── part-00001-90dbdd61-fb92-4fc0-839f-94e498118b03.c000.json
+
+11 directories, 3 files
 ```
 
 ### `gs://a-private-d70d758a4b28a791/`
 
 ```
-      5167  2021-04-26T21:47:50Z  gs://a-private-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/processed/publish/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-f3aa2611-ae8b-49b5-b170-6a81ce2a547f-c000.json
-         0  2021-04-26T21:47:51Z  gs://a-private-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/processed/publish/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:47:52Z  gs://a-private-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/processed/publish/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
+.
+└── gs:
+    └── a-private-d70d758a4b28a791
+        └── test-app
+            └── v1
+                └── C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B
+                    └── test-app
+                        └── 2021-04-27
+                            ├── intermediate
+                            │   └── internal
+                            │       ├── aggregate
+                            │       │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                            │       │       ├── _SUCCESS
+                            │       │       └── part-00000-f5aade7b-b173-40ae-ab1f-8227320cd21c-c000.json
+                            │       ├── verify1
+                            │       │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                            │       │       ├── _SUCCESS
+                            │       │       ├── part-00000-4cce36b2-a0be-4d47-8a97-70a5909325c2-c000.json
+                            │       │       └── part-00001-4cce36b2-a0be-4d47-8a97-70a5909325c2-c000.json
+                            │       └── verify2
+                            │           └── batch_id=content.blocking_blocked_TESTONLY-0
+                            │               ├── _SUCCESS
+                            │               ├── part-00000-87589739-465a-4c4b-8329-8d4be400bf6f-c000.json
+                            │               └── part-00001-87589739-465a-4c4b-8329-8d4be400bf6f-c000.json
+                            └── processed
+                                └── publish
+                                    └── batch_id=content.blocking_blocked_TESTONLY-0
+                                        ├── _SUCCESS
+                                        └── part-00000-806a39fe-12e8-42d2-9a2d-763ac21da8bb-c000.json
+
+18 directories, 10 files
 ```
 
 ### `gs://a-shared-d70d758a4b28a791/`
 
 ```
-      5824  2021-04-26T21:45:21Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-dd0eb436-9328-47a9-975b-8eaf81b277b8-c000.json
-      3185  2021-04-26T21:45:22Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/part-00001-dd0eb436-9328-47a9-975b-8eaf81b277b8-c000.json
-         0  2021-04-26T21:45:23Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:45:23Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-         0  2021-04-26T21:45:34Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/verify1/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-      9100  2021-04-26T21:45:34Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/verify1/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-14e51acd-004f-4510-89ed-6a9cca6d9e89-c000.json
-         0  2021-04-26T21:45:36Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/verify1/_SUCCESS
-      4800  2021-04-26T21:46:15Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-ab7318d9-5588-4188-a2c6-048a9f34391c-c000.json
-      2625  2021-04-26T21:46:16Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/part-00001-ab7318d9-5588-4188-a2c6-048a9f34391c-c000.json
-         0  2021-04-26T21:46:17Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:46:18Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-         0  2021-04-26T21:46:26Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/verify2/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-      7425  2021-04-26T21:46:26Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/verify2/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-85066cff-82f7-4630-9e2a-f01a341cb575-c000.json
-         0  2021-04-26T21:46:27Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/verify2/_SUCCESS
-         0  2021-04-26T21:47:07Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/
-     32760  2021-04-26T21:47:07Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-09b479f7-01a8-4f26-acf0-6a9a9dd754ab-c000.json
-         0  2021-04-26T21:47:08Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/internal/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-         0  2021-04-26T21:47:14Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-     32748  2021-04-26T21:47:14Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-6934ed79-2130-4dec-806c-7989c82fe1ae-c000.json
-         0  2021-04-26T21:47:16Z  gs://a-shared-d70d758a4b28a791/test-app/v1/C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B/test-app/2021-04-26/intermediate/external/aggregate/_SUCCESS
+.
+└── gs:
+    └── a-shared-d70d758a4b28a791
+        └── test-app
+            └── v1
+                └── C629C221FBCF524FE2FC746A0E114749DF18013F893280B4203F20859CA7FC4B
+                    └── test-app
+                        └── 2021-04-27
+                            └── intermediate
+                                └── external
+                                    ├── aggregate
+                                    │   ├── _SUCCESS
+                                    │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                                    │       ├── _SUCCESS
+                                    │       └── part-00000-e74badbf-9ab5-4e62-9238-b368f881b7a9-c000.json
+                                    ├── verify1
+                                    │   ├── _SUCCESS
+                                    │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                                    │       ├── _SUCCESS
+                                    │       └── part-00000-6f55cefd-c443-4d08-b179-9cff80903fa3-c000.json
+                                    └── verify2
+                                        ├── _SUCCESS
+                                        └── batch_id=content.blocking_blocked_TESTONLY-0
+                                            ├── _SUCCESS
+                                            └── part-00000-1a7a7d5b-f0d5-4eb3-a6b0-f2876117f1c3-c000.json
+
+15 directories, 9 files
 ```
 
 ## Server B buckets
@@ -55,44 +100,90 @@ objects stored across the the two servers.
 ### `gs://b-ingest-d70d758a4b28a791/`
 
 ```
-       220  2021-04-26T21:44:37Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/batch_id=bad-id/.part-00000-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json.crc
-        12  2021-04-26T21:44:37Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/batch_id=bad-id/.part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json.crc
-     26821  2021-04-26T21:44:37Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/batch_id=bad-id/part-00000-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json
-       271  2021-04-26T21:44:37Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/batch_id=bad-id/part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json
-       252  2021-04-26T21:44:37Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/batch_id=content.blocking_blocked_TESTONLY-0/.part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json.crc
-     31076  2021-04-26T21:44:37Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/batch_id=content.blocking_blocked_TESTONLY-0/part-00001-dbe4d4cc-2517-4d67-b9bb-90309e8c7f09.c000.json
-         0  2021-04-26T21:44:39Z  gs://b-ingest-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/raw/shares/_SUCCESS
+.
+└── gs:
+    └── b-ingest-d70d758a4b28a791
+        └── test-app
+            └── v1
+                └── E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839
+                    └── test-app
+                        └── 2021-04-27
+                            └── raw
+                                └── shares
+                                    ├── _SUCCESS
+                                    ├── batch_id=bad-id
+                                    │   └── part-00000-90dbdd61-fb92-4fc0-839f-94e498118b03.c000.json
+                                    └── batch_id=content.blocking_blocked_TESTONLY-0
+                                        └── part-00001-90dbdd61-fb92-4fc0-839f-94e498118b03.c000.json
+
+11 directories, 3 files
 ```
 
 ### `gs://b-private-d70d758a4b28a791/`
 
 ```
-      5167  2021-04-26T21:47:51Z  gs://b-private-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/processed/publish/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-58c3b42c-cf6d-4822-865a-dd5fc78c0785-c000.json
-         0  2021-04-26T21:47:52Z  gs://b-private-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/processed/publish/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:47:52Z  gs://b-private-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/processed/publish/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
+.
+└── gs:
+    └── b-private-d70d758a4b28a791
+        └── test-app
+            └── v1
+                └── E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839
+                    └── test-app
+                        └── 2021-04-27
+                            ├── intermediate
+                            │   └── internal
+                            │       ├── aggregate
+                            │       │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                            │       │       ├── _SUCCESS
+                            │       │       └── part-00000-e74badbf-9ab5-4e62-9238-b368f881b7a9-c000.json
+                            │       ├── verify1
+                            │       │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                            │       │       ├── _SUCCESS
+                            │       │       └── part-00000-6f55cefd-c443-4d08-b179-9cff80903fa3-c000.json
+                            │       └── verify2
+                            │           └── batch_id=content.blocking_blocked_TESTONLY-0
+                            │               ├── _SUCCESS
+                            │               └── part-00000-1a7a7d5b-f0d5-4eb3-a6b0-f2876117f1c3-c000.json
+                            └── processed
+                                └── publish
+                                    └── batch_id=content.blocking_blocked_TESTONLY-0
+                                        ├── _SUCCESS
+                                        └── part-00000-a7e8122c-3f79-4d3c-88be-7d08c6863a72-c000.json
+
+18 directories, 8 files
 ```
 
 ### `gs://b-shared-d70d758a4b28a791/`
 
 ```
-      9100  2021-04-26T21:45:27Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-14e51acd-004f-4510-89ed-6a9cca6d9e89-c000.json
-      5824  2021-04-26T21:45:28Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify1/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-dd0eb436-9328-47a9-975b-8eaf81b277b8-c000.json
-         0  2021-04-26T21:45:28Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:45:29Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify1/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-      3185  2021-04-26T21:45:29Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify1/batch_id=content.blocking_blocked_TESTONLY-0/part-00001-dd0eb436-9328-47a9-975b-8eaf81b277b8-c000.json
-         0  2021-04-26T21:45:29Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/verify1/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-         0  2021-04-26T21:45:30Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify1/_SUCCESS
-      7425  2021-04-26T21:46:18Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-85066cff-82f7-4630-9e2a-f01a341cb575-c000.json
-         0  2021-04-26T21:46:19Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:46:20Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/verify2/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-         0  2021-04-26T21:46:24Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify2/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-      4800  2021-04-26T21:46:24Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify2/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-ab7318d9-5588-4188-a2c6-048a9f34391c-c000.json
-      2625  2021-04-26T21:46:24Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify2/batch_id=content.blocking_blocked_TESTONLY-0/part-00001-ab7318d9-5588-4188-a2c6-048a9f34391c-c000.json
-         0  2021-04-26T21:46:26Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/verify2/_SUCCESS
-     32748  2021-04-26T21:47:07Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-6934ed79-2130-4dec-806c-7989c82fe1ae-c000.json
-         0  2021-04-26T21:47:08Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/
-         0  2021-04-26T21:47:08Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/internal/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-         0  2021-04-26T21:47:14Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/_SUCCESS
-     32760  2021-04-26T21:47:14Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/aggregate/batch_id=content.blocking_blocked_TESTONLY-0/part-00000-09b479f7-01a8-4f26-acf0-6a9a9dd754ab-c000.json
-         0  2021-04-26T21:47:16Z  gs://b-shared-d70d758a4b28a791/test-app/v1/E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839/test-app/2021-04-26/intermediate/external/aggregate/_SUCCESS
+.
+└── gs:
+    └── b-shared-d70d758a4b28a791
+        └── test-app
+            └── v1
+                └── E58761F983D681367F854C4DE70D2BFA7BE6CDE79422B57B4B850ABD7FCB6839
+                    └── test-app
+                        └── 2021-04-27
+                            └── intermediate
+                                └── external
+                                    ├── aggregate
+                                    │   ├── _SUCCESS
+                                    │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                                    │       ├── _SUCCESS
+                                    │       └── part-00000-f5aade7b-b173-40ae-ab1f-8227320cd21c-c000.json
+                                    ├── verify1
+                                    │   ├── _SUCCESS
+                                    │   └── batch_id=content.blocking_blocked_TESTONLY-0
+                                    │       ├── _SUCCESS
+                                    │       ├── part-00000-4cce36b2-a0be-4d47-8a97-70a5909325c2-c000.json
+                                    │       └── part-00001-4cce36b2-a0be-4d47-8a97-70a5909325c2-c000.json
+                                    └── verify2
+                                        ├── _SUCCESS
+                                        └── batch_id=content.blocking_blocked_TESTONLY-0
+                                            ├── _SUCCESS
+                                            ├── part-00000-87589739-465a-4c4b-8329-8d4be400bf6f-c000.json
+                                            └── part-00001-87589739-465a-4c4b-8329-8d4be400bf6f-c000.json
+
+15 directories, 11 files
 ```
+

--- a/deployment/testing-v4/scripts/list-bucket
+++ b/deployment/testing-v4/scripts/list-bucket
@@ -17,7 +17,11 @@ fi
 function sort_recursive_listing {
     local bucket=$1
     # remove lines that end with /:, empty lines, or the summary line
-    gsutil ls -lr "$bucket" | grep -v :$ | grep -v ^$ | grep -v ^TOTAL | sort -k2
+    # then remove extra spacing, sort by date, and take the name of the path
+    gsutil ls -lr "$bucket" | \
+        grep -v :$ | grep -v ^$ | grep -v ^TOTAL | \
+        tr -s " " | sort -k2 | cut -d " " -f4 | \
+        tree --fromfile
 }
 
 cat << EOF


### PR DESCRIPTION
I was looking through the process script and noticed that the internal intermediate results (the shares meant for the next stage, for the current processor) are being put into a shared bucket. This moves it into the private bucket. The bucket prefixes will remain the same, since it means the two file systems can be overlaid without any name conflicts. 

I also found out about `tree --fromfile` which makes the output from the gsutil listing easier on the eyes. I updated the guide with the current storage convention.