### PR TITLE
Pin minio image and update README for missing envvars to edit during minio credential rotation

### DIFF
--- a/deployment/testing-v4-gcloud-self/README.md
+++ b/deployment/testing-v4-gcloud-self/README.md
@@ -138,6 +138,12 @@ BUCKET_INTERNAL_PRIVATE=...     # .buckets.private
 BUCKET_INTERNAL_SHARED=...      # .buckets.shares
 BUCKET_INTERNAL_ACCESS_KEY=...  # .keys.internal.access_key
 BUCKET_INTERNAL_SECRET_KEY=...  # .keys.internal.secret_key
+
+# NOTE: the external keys are the same as the internal keys because access to
+# server A is being proxied through the minio instance. Therefore, the proxy
+# should be configured with a keypair known only to server B.
+BUCKET_EXTERNAL_ACCESS_KEY=...  # .keys.internal.access_key
+BUCKET_EXTERNAL_SECRET_KEY=...  # .keys.internal.secret_key
 ```
 
 The default endpoint of `http://minio-b:9000` will suffice for local access by

--- a/deployment/testing-v4-gcloud-self/README.md
+++ b/deployment/testing-v4-gcloud-self/README.md
@@ -126,9 +126,11 @@ In server B, to generate new buckets and access keys, run the following command:
 scripts/generate-minio-configuration
 ```
 
+#### Modifying internal environment variables
+
 This will create a new file called `.secrets/minio-config.json` with bucket
-names, policy files, and access keys. Replace the following variables with values
-from the configuration file:
+names, policy files, and access keys. Replace the following variables in the
+`.env` file with values from the configuration file:
 
 ```bash
 BUCKET_INTERNAL_INGEST=...      # .buckets.ingest
@@ -145,22 +147,31 @@ Before providing variables for the external and ingestion services, ensure MinIO
 is available to the public internet. By default, the MinIO service is made
 available to the host on port 9004. Forward this port to and provide the
 following as the endpoint: `http://{host}:{port}`. Alternatively, change port
-9004 to 80. It may be preferable to provide this via reverse-proxy ala NGINX.
+9004 to 80. It may be preferable to provide this [via reverse-proxy ala
+NGINX](https://docs.min.io/docs/setup-nginx-proxy-with-minio.html). If using a
+reverse proxy, [ensure that host
+headers](https://github.com/minio/minio/issues/7936) are being proxied
+correctly.
 
-Then, provide the following variables for the ingestion service:
+#### Providing external partners with environment variables
+
+The following environment variables are named from the perspective of the
+running server. Create a new text file with the following variables for the
+ingestion service and send them to the partner via a secured channel:
 
 ```bash
-PUBLIC_KEY_HEX_EXTERNAL=...     # public key
+PUBLIC_KEY_HEX_EXTERNAL=...     # public key of server B
 BUCKET_EXTERNAL_INGEST=...      # .buckets.ingest
 BUCKET_EXTERNAL_ACCESS_KEY=...  # .keys.ingest.access_key
 BUCKET_EXTERNAL_SECRET_KEY=...  # .keys.ingest.secret_key
 BUCKET_EXTERNAL_ENDPOINT=...    # endpoint computed above
 ```
 
-Provide the following variables for server a:
+Create a new text file with the following variables for server A and send them
+to the partner via a secured channel.
 
 ```bash
-PUBLIC_KEY_HEX_EXTERNAL=...     # public key
+PUBLIC_KEY_HEX_EXTERNAL=...     # public key of server B
 BUCKET_EXTERNAL_SHARED=...      # .buckets.shared
 BUCKET_EXTERNAL_ACCESS_KEY=...  # .keys.external.access_key
 BUCKET_EXTERNAL_SECRET_KEY=...  # .keys.external.secret_key

--- a/deployment/testing-v4-gcloud-self/compose/ingest/docker-compose.yml
+++ b/deployment/testing-v4-gcloud-self/compose/ingest/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
   # https://docs.min.io/docs/minio-gateway-for-gcs.html
   gcs-gateway-ingest:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     command: gateway gcs ${CLOUDSDK_CORE_PROJECT}
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS?"missing credentials"}:/tmp/.credentials

--- a/deployment/testing-v4-gcloud-self/compose/server-a/docker-compose.yml
+++ b/deployment/testing-v4-gcloud-self/compose/server-a/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 services:
   # https://docs.min.io/docs/minio-gateway-for-gcs.html
   gcs-gateway-a:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     command: gateway gcs
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS?"missing credentials"}:/tmp/.credentials
@@ -52,3 +52,6 @@ services:
       - BUCKET_EXTERNAL_SHARED
       - BUCKET_PREFIX
       - SUBMISSION_DATE
+      - RETRY_LIMIT
+      - RETRY_DELAY
+      - RETRY_BACKOFF_EXPONENT

--- a/deployment/testing-v4-gcloud-self/compose/server-b/docker-compose.yml
+++ b/deployment/testing-v4-gcloud-self/compose/server-b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   minio-b:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     command: server /data
     ports:
       - 9004:9000
@@ -26,7 +26,7 @@ services:
 
   # https://docs.min.io/docs/minio-gateway-for-gcs.html
   gcs-gateway-b:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     command: gateway gcs
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS?"missing credentials"}:/tmp/.credentials
@@ -68,4 +68,6 @@ services:
       - BUCKET_EXTERNAL_SHARED
       - BUCKET_PREFIX
       - SUBMISSION_DATE
-      - RETRY_LIMIT=10
+      - RETRY_LIMIT
+      - RETRY_DELAY
+      - RETRY_BACKOFF_EXPONENT


### PR DESCRIPTION
During testing, a few bugs were discovered in this testing configuration. First, breaking changes to the minio image caused `mc` to fail. Secondly, during a credential rotation of server B, the documentation fails to mention two variables that must be changed in the GCS proxy in order to connect to the external bucket correctly.