### PR TITLE
Add spark.ui.showConsoleProgress true

### DIFF
--- a/config/spark/spark-defaults.conf.template
+++ b/config/spark/spark-defaults.conf.template
@@ -37,5 +37,6 @@ spark.hadoop.fs.s3a.socket.send.buffer 65536
 spark.hadoop.fs.s3a.threads.max 2048
 
 # add the progress bar to update the console for Airflow timeouts (relevant
-# if running using the KubernetesPodOperator).
+# if running using the KubernetesPodOperator with Airflow: 
+# https://github.com/mozilla/telemetry-airflow/issues/844).
 spark.ui.showConsoleProgress true

--- a/config/spark/spark-defaults.conf.template
+++ b/config/spark/spark-defaults.conf.template
@@ -35,3 +35,7 @@ spark.hadoop.fs.s3a.socket.recv.buffer 65536
 spark.hadoop.fs.s3a.socket.send.buffer 65536
  # maximum number of threads for S3A
 spark.hadoop.fs.s3a.threads.max 2048
+
+# add the progress bar to update the console for Airflow timeouts (relevant
+# if running using the KubernetesPodOperator).
+spark.ui.showConsoleProgress true


### PR DESCRIPTION
The container may stop updating standard out, which poses a problem for airflow (https://github.com/mozilla/telemetry-airflow/issues/844). This adds an option to show the console progress, which runs on tasks that take more than 500ms to run. An alternative is update `config/spark/log4j.properties` where `log4j.rootCategory=INFO, console`,  which is far more verbose.